### PR TITLE
Various improvements

### DIFF
--- a/keymaps/kd.json
+++ b/keymaps/kd.json
@@ -1,5 +1,6 @@
 {
   "atom-workspace": {
+    "alt-k alt-d": "kd:dashboard",
     "alt-k alt-t": "kd:teams",
     "alt-k alt-v": "kd:machines",
     "alt-k alt-m": "kd:mounts"

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,16 @@
+'use babel'
+
+export default {
+  localBasePath: {
+    type: 'string',
+    description: 'Local base path for mounting machines',
+    default: `${require('os').homedir()}/koding`
+  },
+  kdBinaryPath: {
+    type: 'string',
+    description: `If you have installed <code>kd</code>
+                  somewhere other than the default installation path,
+                  you can enter the installation path here.`,
+    default: '/usr/local/bin/kd'
+  }
+}

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -145,7 +145,6 @@ export default class KDController extends kd.Object {
 
     view.emitter.on('machine-settings:open-terminal', ({ machine }) => {
       this.openTerminal({ machine })
-      panel.destroy()
     })
 
     view.emitter.on('machine-settings:reload', () => {

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -148,6 +148,11 @@ export default class KDController extends kd.Object {
       panel.destroy()
     })
 
+    view.emitter.on('machine-settings:reload', () => {
+      this.showMachines(null, true)
+      panel.destroy()
+    })
+
     if (onMount) {
       view.emitter.on('machine-settings:mount', onMount)
     }
@@ -162,15 +167,17 @@ export default class KDController extends kd.Object {
     }
   }
 
-  async showMachines (team = null) {
+  async showMachines (team = null, reload = false) {
     log('show machine settings')
     this.showLoading('Loading machines…')
 
-    let machines
-    try {
-      machines = await getMachines(team)
-      this.getData().machines = machines
-    } catch (e) { return this._err(e) }
+    let machines = this.getData().machines
+    if (!machines || reload) {
+      try {
+        machines = await getMachines(team)
+        this.getData().machines = machines
+      } catch (e) { return this._err(e) }
+    }
 
     this.hideLoading()
 

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -143,6 +143,11 @@ export default class KDController extends kd.Object {
       panel.destroy()
     })
 
+    view.emitter.on('machine-settings:open-terminal', ({ machine }) => {
+      this.openTerminal({ machine })
+      panel.destroy()
+    })
+
     if (onMount) {
       view.emitter.on('machine-settings:mount', onMount)
     }
@@ -197,6 +202,14 @@ export default class KDController extends kd.Object {
 
   onUnmount ({ machine }) {
     log('unmount machine not implemented yet', { machine })
+  }
+
+  openTerminal ({ machine }) {
+    // implement initial command based on machine
+    let activeEditor = atom.views.getView(
+      atom.workspace.getActiveTextEditor()
+    )
+    atom.commands.dispatch(activeEditor, 'atom-terminal:open')
   }
 
   runMountCmd (machine, options = {}) {

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -118,7 +118,7 @@ export default class KDController extends kd.Object {
       this.getData().teams = teams
     } catch (e) { return this._err(e) }
 
-    this.showLoading('Selecting team...')
+    this.showLoading('Selecting team…')
     this.showTeamsSelector(teams, {
       onConfirm: team => {
         this.getData().team = team
@@ -213,7 +213,7 @@ export default class KDController extends kd.Object {
     const localPath = `${localBasePath}/${machine.team}/${machine.label}`
     const remotePath = `/home/${machine.owner || machine.username}`
 
-    this.showLoading('Selecting folders...')
+    this.showLoading('Selecting folders…')
     const panel = this.showPrompt({
       prompts: makePrompts(remotePath, localPath),
       callback: (err, inputs) => {
@@ -225,7 +225,7 @@ export default class KDController extends kd.Object {
         const { localPath, remotePath } = inputs
         const remoteAddress = `${machine.id}:${remotePath}`
 
-        this.showLoading('Mounting...')
+        this.showLoading('Mounting…')
 
         this.runMountCmd(machine, {
           remote: remoteAddress,

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -12,6 +12,7 @@ import getTeams from './utils/get-teams'
 import getMachines from './utils/get-machines'
 import getMounts from './utils/get-mounts'
 import showTreeView from './utils/show-tree-view'
+import StatusBarIcon from './views/statusbar-icon'
 
 const log = debug('kd-controller:log')
 const error = debug('kd:err')
@@ -316,6 +317,25 @@ export default class KDController extends kd.Object {
         this.hideLoading()
       }
     })
+  }
+
+  consumeStatusBar (statusBar) {
+    this.statusBarItem = new StatusBarIcon({
+      callback: (method) => { this[method] && this[method]() }
+    })
+    this.statusBarTile = statusBar.addRightTile({
+      item: this.statusBarItem,
+      priority: 100
+    })
+  }
+
+  destroy () {
+    this.statusBarTile.destroy()
+    this.statusBarItem.destroy()
+    this.statusBarTile = null
+    this.statusBarItem = null
+
+    super.destroy()
   }
 }
 

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -3,7 +3,6 @@
 
 import kd from 'kd.js'
 import debug from 'debug'
-import execa from 'execa'
 import KD from './kd-states'
 import PromptView from './views/prompt-view'
 import TeamSelector from './views/team-selector'
@@ -222,7 +221,7 @@ export default class KDController extends kd.Object {
   runMountCmd (machine, options = {}) {
     const { remote, local, onConfirm, onError } = options
 
-    execa('kd', ['machine', 'mount', remote, local])
+    require('./utils/kd-run')(['machine', 'mount', remote, local])
       .then(result => {
         onConfirm && onConfirm()
       }).catch(e => {

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -122,7 +122,7 @@ export default class KDController extends kd.Object {
     this.showTeamsSelector(teams, {
       onConfirm: team => {
         this.getData().team = team
-        this.showMachineSettings(team.slug)
+        this.showMachines(team.slug)
       },
       onCancel: this.bound('hideLoading')
     })
@@ -157,7 +157,7 @@ export default class KDController extends kd.Object {
     }
   }
 
-  async showMachineSettings (team = null) {
+  async showMachines (team = null) {
     log('show machine settings')
     this.showLoading('Loading machines…')
 

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -123,7 +123,8 @@ export default class KDController extends kd.Object {
       onConfirm: team => {
         this.getData().team = team
         this.showMachineSettings(team.slug)
-      }
+      },
+      onCancel: this.bound('hideLoading')
     })
   }
 
@@ -172,7 +173,8 @@ export default class KDController extends kd.Object {
       onAlwaysOnChange: this.bound('setAlwaysOn'),
       onPowerChange: this.bound('setPowerState'),
       onShowLogs: this.bound('showBuildLogs'),
-      onMount: this.bound('onMount')
+      onMount: this.bound('onMount'),
+      onCancel: this.bound('hideLoading')
     })
   }
 

--- a/lib/kd-states.js
+++ b/lib/kd-states.js
@@ -3,9 +3,11 @@
 import execa from 'execa'
 import debug from 'debug'
 import { Emitter } from 'atom'
+import getKdPath from './utils/get-kd-path'
 
 const log = debug('kd-state:log')
 const error = debug('kd-state:err')
+const kdPath = getKdPath()
 
 const STATES = {
   NOT_INSTALLED: 'NOT_INSTALLED',
@@ -17,19 +19,19 @@ const STATES = {
 const checkers = {
   isKDInstalled: {
     state: 'NOT_INSTALLED',
-    fn: execa.bind(this, 'which', ['kd'])
+    fn: execa.bind(this, 'which', [kdPath])
   },
   isDaemonInstalled: {
     state: 'DAEMON_NOT_INSTALLED',
-    fn: execa.bind(this, 'kd', ['status'])
+    fn: execa.bind(this, kdPath, ['status'])
   },
   // isDaemonStopped: {
   //   state: 'DAEMON_STOPPED',
-  //   fn: execa.bind(this, 'kd', ['list'])
+  //   fn: execa.bind(this, kdPath, ['list'])
   // },
   isLoggedIn: {
     state: 'NOT_LOGGEDIN',
-    fn: execa.bind(this, 'kd', ['team', 'show'])
+    fn: execa.bind(this, kdPath, ['team', 'show'])
   }
 }
 

--- a/lib/kd-states.js
+++ b/lib/kd-states.js
@@ -59,7 +59,7 @@ function check (prompt) {
       check(nextPrompt)
     } else {
       log('kd-is-in-good-shape')
-      emitter.emit('kd-state', 'ALL_GOOD')
+      emitter.emit('kd-state-all-good')
       emitter.emit('ready')
     }
   }).catch(err => {

--- a/lib/kd.js
+++ b/lib/kd.js
@@ -36,13 +36,13 @@ export default {
   bindEvents () {
     let controller = this.kdController
     this.subscriptions.add(atom.commands.add('atom-workspace', {
-      'kd:teams': () => { this.teamSelector() },
+      'kd:teams': () => { controller.showTeams() },
       'kd:machines': () => { controller.showMachines() },
       'kd:mounts': () => { controller.showMounts() },
       'kd:terminal': () => {
         controller.openTerminal({ machine: controller.getData().machine })
       },
-      'kd:dashboard': () => { this.statusBarItem.trigger('click') }
+      'kd:dashboard': () => { controller.statusBarItem.trigger('click') }
     }))
   },
 
@@ -59,7 +59,6 @@ export default {
   resetStorage () {
     this.storage.reset()
     this.kdController.reset()
-    this.login()
   },
 
   consumeStatusBar (statusBar) {

--- a/lib/kd.js
+++ b/lib/kd.js
@@ -6,7 +6,6 @@ import debug from 'debug'
 import config from './config'
 import KD from './kd-states'
 import KDController from './kd-controller'
-import StatusBarIcon from './views/statusbar-icon'
 import checkAtomDeps from './utils/check-atom-deps'
 import StorageController from './controllers/storage-controller'
 
@@ -26,6 +25,7 @@ export default {
 
     this.storage.deserialize(state).then(data => {
       this.kdController = new KDController(data)
+      this.kdController.consumeStatusBar(this.statusBarRegistry)
     }).catch(err => error('can not deserialize', err))
 
     KD.emitter.on('ready', this.bindEvents.bind(this))
@@ -51,15 +51,9 @@ export default {
   },
 
   deactivate () {
+    this.statusBarRegistry = null
     this.subscriptions.dispose()
-    this.statusBarTile.destroy()
-    this.statusBarItem.destroy()
-    this.statusBarTile = null
-    this.statusBarItem = null
-  },
-
-  teamSelector () {
-    this.kdController.showTeams()
+    this.kdController.destroy()
   },
 
   resetStorage () {
@@ -70,11 +64,6 @@ export default {
 
   consumeStatusBar (statusBar) {
     this.statusBarRegistry = statusBar
-    this.statusBarItem = new StatusBarIcon()
-    this.statusBarTile = statusBar.addRightTile({
-      item: this.statusBarItem,
-      priority: 100
-    })
   }
 
 }

--- a/lib/kd.js
+++ b/lib/kd.js
@@ -48,7 +48,8 @@ export default {
           atom.workspace.getActiveTextEditor()
         )
         atom.commands.dispatch(activeEditor, 'atom-terminal:open')
-      }
+      },
+      'kd:dashboard': () => { this.statusBarItem.trigger('click') }
     }))
   },
 

--- a/lib/kd.js
+++ b/lib/kd.js
@@ -39,15 +39,13 @@ export default {
   },
 
   bindEvents () {
+    let controller = this.kdController
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'kd:teams': () => { this.teamSelector() },
-      'kd:machines': () => { this.kdController.showMachines() },
-      'kd:mounts': () => { this.kdController.showMounts() },
+      'kd:machines': () => { controller.showMachines() },
+      'kd:mounts': () => { controller.showMounts() },
       'kd:terminal': () => {
-        let activeEditor = atom.views.getView(
-          atom.workspace.getActiveTextEditor()
-        )
-        atom.commands.dispatch(activeEditor, 'atom-terminal:open')
+        controller.openTerminal({ machine: controller.getData().machine })
       },
       'kd:dashboard': () => { this.statusBarItem.trigger('click') }
     }))

--- a/lib/kd.js
+++ b/lib/kd.js
@@ -41,7 +41,7 @@ export default {
   bindEvents () {
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'kd:teams': () => { this.teamSelector() },
-      'kd:machines': () => { this.kdController.showMachineSettings() },
+      'kd:machines': () => { this.kdController.showMachines() },
       'kd:mounts': () => { this.kdController.showMounts() },
       'kd:terminal': () => {
         let activeEditor = atom.views.getView(

--- a/lib/kd.js
+++ b/lib/kd.js
@@ -3,6 +3,7 @@
 
 import { CompositeDisposable } from 'atom'
 import debug from 'debug'
+import config from './config'
 import KD from './kd-states'
 import KDController from './kd-controller'
 import StatusBarIcon from './views/statusbar-icon'
@@ -16,13 +17,7 @@ export default {
 
   kdController: null,
 
-  config: {
-    localBasePath: {
-      type: 'string',
-      description: 'Local base path for mounting machines',
-      default: `${require('os').homedir()}/koding`
-    }
-  },
+  config: config,
 
   activate (state) {
     log('kd activated!', state)

--- a/lib/utils/get-kd-path.js
+++ b/lib/utils/get-kd-path.js
@@ -1,0 +1,6 @@
+'use babel'
+/* globals atom */
+
+export default function getKdPath (commands) { 
+  return atom.config.get('kd.kdBinaryPath') || 'kd'
+}

--- a/lib/utils/get-machines.js
+++ b/lib/utils/get-machines.js
@@ -9,6 +9,6 @@ export default function getMachines (team) {
       if (team) {
         machines = machines.filter(machine => machine.team === team)
       }
-      return machines.filter(machine => machine.status.state > 1)
+      return machines
     })
 }

--- a/lib/utils/get-machines.js
+++ b/lib/utils/get-machines.js
@@ -1,9 +1,9 @@
 'use babel'
 
-import execa from 'execa'
+import kd from './kd-run'
 
 export default function getMachines (team) {
-  return execa('kd', ['machine', 'list', '--json'])
+  return kd('machine list --json')
     .then(result => {
       let machines = JSON.parse(result.stdout)
       if (team) {

--- a/lib/utils/get-mounts.js
+++ b/lib/utils/get-mounts.js
@@ -1,9 +1,9 @@
 'use babel'
 
-import execa from 'execa'
+import kd from './kd-run'
 
 export default function getMounts () {
-  return execa('kd', ['machine', 'mount', 'list', '--json'])
+  return kd('machine mount list --json')
     .then(result => {
       let mountsObj = JSON.parse(result.stdout)
       let mounts = []

--- a/lib/utils/get-teams.js
+++ b/lib/utils/get-teams.js
@@ -1,8 +1,8 @@
 'use babel'
 
-import execa from 'execa'
+import kd from './kd-run'
 
 export default function getTeams () {
-  return execa('kd', ['team', 'list', '--json'])
+  return kd('team list --json')
     .then(result => JSON.parse(result.stdout))
 }

--- a/lib/utils/kd-run.js
+++ b/lib/utils/kd-run.js
@@ -1,0 +1,13 @@
+'use babel'
+
+import execa from 'execa'
+import getKdPath from './get-kd-path'
+
+const kdPath = getKdPath()
+
+export default function runKd (commands) {
+  if (!Array.isArray(commands)) {
+    commands = commands.split(' ')
+  }
+  return execa(kdPath, commands)
+}

--- a/lib/views/command-center.js
+++ b/lib/views/command-center.js
@@ -1,0 +1,42 @@
+'use babel'
+/* globals atom */
+
+import { View } from 'atom-space-pen-views'
+
+export default class CommandCenterView extends View {
+
+  static content (data = {}) {
+    this.div(() => {
+      this.div({ outlet: 'content' }, () => {
+        this.h2(() => {
+          this.code('kd')
+          this.text('is up & running')
+        })
+        this.p(() => {
+          this.text(`The daemon is running. You're logged in!`)
+          this.raw('<br><br>')
+          this.raw(`Now you can open the command palette
+                   (<code>!!!!</code>) and type <code>kd</code>
+                   to see the available commands.`)
+        })
+        this.button({ click: 'show', class: 'btn' }, 'Machines')
+        this.button({ click: 'show', class: 'btn' }, 'Teams')
+        this.button({ click: 'show', class: 'btn' }, 'Mounts')
+      })
+    })
+  }
+
+  // close () {
+  //   let { statusBarItem } = atom.packages.getActivePackage('kd').mainModule
+  //   statusBarItem.clearDisposable()
+  // }
+
+  show (event) {
+    console.log(arguments)
+    let target = event.target.innerHTML
+    let { kdController } = atom.packages.getActivePackage('kd').mainModule
+    kdController[`show${target}`]()
+    // this.close()
+  }
+
+}

--- a/lib/views/command-center.js
+++ b/lib/views/command-center.js
@@ -11,7 +11,7 @@ const log = debug('command-center:log')
 export default class CommandCenterView extends View {
 
   static content (data = {}) {
-    this.div(() => {
+    this.div({ class: 'command-center' }, () => {
       this.div({ outlet: 'content' }, () => {
         this.h2(() => {
           this.code('kd')
@@ -21,25 +21,37 @@ export default class CommandCenterView extends View {
             click: 'close'
           })
         })
-        this.p(() => {
-          this.text(`The daemon is running. You're logged in!`)
-          this.raw('<br><br>')
+
+        this.div({
+          class: 'icon icon-check'
+        }, `The daemon is running.`)
+        this.div({
+          class: 'icon icon-check'
+        }, `You're logged in!`)
+
+        this.div({ class: 'buttons' }, () => {
+          this.button({
+            click: 'show',
+            class: 'btn btn-sm btn-info icon icon-server' }
+          , 'Machines')
+          this.button({
+            click: 'show',
+            class: 'btn btn-sm icon icon-organization' }
+          , 'Teams')
+          this.button({
+            click: 'show',
+            class: 'btn btn-sm icon icon-desktop-download' }
+          , 'Mounts')
+        })
+
+        this.div({
+          class: 'alert text icon icon-question',
+          outlet: 'infobox'
+        }, () => {
           this.raw(`Now you can open the command palette
                    (<code>!!!!</code>) and type <code>kd</code>
                    to see the available commands.`)
         })
-        this.button({
-          click: 'show',
-          class: 'btn btn-sm icon icon-server' }
-        , 'Machines')
-        this.button({
-          click: 'show',
-          class: 'btn btn-sm icon icon-organization' }
-        , 'Teams')
-        this.button({
-          click: 'show',
-          class: 'btn btn-sm icon icon-desktop-download' }
-        , 'Mounts')
       })
     })
   }

--- a/lib/views/command-center.js
+++ b/lib/views/command-center.js
@@ -1,5 +1,4 @@
 'use babel'
-/* globals atom */
 
 import debug from 'debug'
 import { Emitter } from 'atom'
@@ -69,11 +68,10 @@ export default class CommandCenterView extends View {
   }
 
   show (event) {
-    log(arguments)
-    this.close()
     let target = event.target.innerHTML
-    let { kdController } = atom.packages.getActivePackage('kd').mainModule
-    kdController[`show${target}`]()
+    log(`show${target}`)
+    this.emitter.emit(`command-center:button-clicked`, target)
+    this.close()
   }
 
 }

--- a/lib/views/command-center.js
+++ b/lib/views/command-center.js
@@ -1,7 +1,11 @@
 'use babel'
 /* globals atom */
 
+import debug from 'debug'
+import { Emitter } from 'atom'
 import { View } from 'atom-space-pen-views'
+
+const log = debug('command-center:log')
 
 export default class CommandCenterView extends View {
 
@@ -11,6 +15,10 @@ export default class CommandCenterView extends View {
         this.h2(() => {
           this.code('kd')
           this.text('is up & running')
+          this.span({
+            class: 'icon icon-x x pull-right',
+            click: 'close'
+          })
         })
         this.p(() => {
           this.text(`The daemon is running. You're logged in!`)
@@ -26,17 +34,20 @@ export default class CommandCenterView extends View {
     })
   }
 
-  // close () {
-  //   let { statusBarItem } = atom.packages.getActivePackage('kd').mainModule
-  //   statusBarItem.clearDisposable()
-  // }
+  initialize () {
+    this.emitter = new Emitter()
+  }
+
+  close (event) {
+    this.emitter.emit('help-view-close-clicked')
+  }
 
   show (event) {
-    console.log(arguments)
+    log(arguments)
+    this.close()
     let target = event.target.innerHTML
     let { kdController } = atom.packages.getActivePackage('kd').mainModule
     kdController[`show${target}`]()
-    // this.close()
   }
 
 }

--- a/lib/views/command-center.js
+++ b/lib/views/command-center.js
@@ -27,9 +27,18 @@ export default class CommandCenterView extends View {
                    (<code>!!!!</code>) and type <code>kd</code>
                    to see the available commands.`)
         })
-        this.button({ click: 'show', class: 'btn' }, 'Machines')
-        this.button({ click: 'show', class: 'btn' }, 'Teams')
-        this.button({ click: 'show', class: 'btn' }, 'Mounts')
+        this.button({
+          click: 'show',
+          class: 'btn btn-sm icon icon-server' }
+        , 'Machines')
+        this.button({
+          click: 'show',
+          class: 'btn btn-sm icon icon-organization' }
+        , 'Teams')
+        this.button({
+          click: 'show',
+          class: 'btn btn-sm icon icon-desktop-download' }
+        , 'Mounts')
       })
     })
   }

--- a/lib/views/command-center.js
+++ b/lib/views/command-center.js
@@ -4,6 +4,7 @@
 import debug from 'debug'
 import { Emitter } from 'atom'
 import { View } from 'atom-space-pen-views'
+import getKeybinding from '../utils/get-keybinding'
 
 const log = debug('command-center:log')
 
@@ -45,6 +46,10 @@ export default class CommandCenterView extends View {
 
   initialize () {
     this.emitter = new Emitter()
+    setTimeout(() => {
+      let binding = getKeybinding('command-palette:toggle')
+      this.infobox.html(this.infobox.html().replace('!!!!', binding))
+    }, 1000)
   }
 
   close (event) {

--- a/lib/views/kd-help-view.js
+++ b/lib/views/kd-help-view.js
@@ -4,16 +4,6 @@
 import { Emitter } from 'atom'
 import { View } from 'atom-space-pen-views'
 import { logo } from '../../assets/svgs'
-import getKeybinding from '../utils/get-keybinding'
-
-/* when this file is run the keybindings aren't ready yet
- that's why giving atom some time to prepare before we ask
- for the keybinding */
-setTimeout(() => {
-  const keybinding = getKeybinding('command-palette:toggle')
-  const { ALL_GOOD } = descriptions
-  ALL_GOOD.description = ALL_GOOD.description.replace('!!!!', keybinding)
-}, 3000)
 
 const descriptions = {
   NOT_INSTALLED: {
@@ -43,23 +33,7 @@ const descriptions = {
       <code>kd</code> daemon is not running please run it with the following
       command:
     `
-  },
-  ALL_GOOD: {
-    title: '<code>kd</code> is up & running',
-    description: `
-      The daemon is running. You're logged in! <br><br>
-
-      Now you can open the command palette(<code>!!!!</code>) and type
-      <code>kd</code> to see the available commands.
-    `
   }
-}
-
-const success = {
-  NOT_INSTALLED: 'kd is installed',
-  NOT_LOGGEDIN: 'you are logged in',
-  DAEMON_NOT_INSTALLED: 'kd daemon is installed',
-  DAEMON_STOPPED: 'kd daemon is running'
 }
 
 const helpers = {
@@ -87,11 +61,7 @@ export default class KDHelpView extends View {
       if (!data.mini) {
         this.div({ class: 'kd-help-view--logo' }, () => { this.raw(logo) })
       }
-      this.div({ outlet: 'content', click: 'click' }, () => {
-        this.raw(`
-          <div class='icon icon-hourglass'>checking <code>kd</code>…</div>
-        `)
-      })
+      this.div({ outlet: 'content', click: 'click' })
     })
   }
 
@@ -105,17 +75,11 @@ export default class KDHelpView extends View {
   }
 
   initialize (data) {
-    let { prompt, succeeded } = data
+    let { prompt } = data
     this.setData(data)
     this.emitter = new Emitter()
-    if (prompt) {
-      this.setContent(prompt)
-    }
-    if (!prompt && succeeded.length) {
-      succeeded.forEach(step => {
-        this.appendContent(step)
-      })
-    }
+    if (!prompt) { return }
+    this.setContent(prompt)
   }
 
   setContent (prompt) {
@@ -157,12 +121,6 @@ export default class KDHelpView extends View {
       icon: 'clippy',
       description: `\`${command}\``
     })
-  }
-
-  appendContent (step) {
-    if (success[step]) {
-      this.content.append(`<div class='icon icon-check'>${success[step]}</div>`)
-    }
   }
 
 }

--- a/lib/views/kd-help-view.js
+++ b/lib/views/kd-help-view.js
@@ -92,7 +92,9 @@ export default class KDHelpView extends View {
         commandsHTML += '<br>'
       }
     }
-    this.content.append(`<h2>${descriptions[prompt].title}</h2>`)
+    this.content.append(`
+      <h2>${descriptions[prompt].title}
+      <span class='icon icon-x x pull-right'></span></h2>`)
     this.content.append(`<p>${descriptions[prompt].description}</p>`)
     if (commandsHTML) {
       this.content.append(`<pre>${commandsHTML}</pre>`)
@@ -100,6 +102,9 @@ export default class KDHelpView extends View {
   }
 
   click (event) {
+    if (event.target.classList.contains('icon-x')) {
+      return this.emitter.emit('help-view-close-clicked')
+    }
     if (event.target.classList.contains('clippy')) {
       return this.copyToClipboard(event)
     }

--- a/lib/views/machine-settings.js
+++ b/lib/views/machine-settings.js
@@ -89,7 +89,6 @@ export default class MachineSettings extends View {
       this.table({ class: 'table text' }, () => {
         this.thead(() => {
           this.tr(() => {
-            // this.th('id')
             this.th('Alias')
             this.th('Team')
             this.th('Machine Label')
@@ -140,7 +139,7 @@ export default class MachineSettings extends View {
                     click: 'onShowLogs',
                     'data-index': index
                   },
-                  'show logs'
+                  'Logs…'
                 )
               })
               this.td(() => this.button(
@@ -149,7 +148,7 @@ export default class MachineSettings extends View {
                   click: 'onMount',
                   'data-index': index
                 },
-                'Mount...'
+                'Mount…'
               ))
               this.td({ class: 'centered' }, () => {
                 this.input({

--- a/lib/views/machine-settings.js
+++ b/lib/views/machine-settings.js
@@ -61,6 +61,14 @@ export default class MachineSettings extends View {
     this.emitter.emit('machine-settings:show-logs', { machine })
   }
 
+  onTerminal (event, element) {
+    const machine = this.machines[element.data('index')]
+
+    if (!machine) { return }
+
+    this.emitter.emit('machine-settings:open-terminal', { machine })
+  }
+
   static content ({ machines }) {
     this.section({ class: 'section machine-settings' }, () => {
       this.div({ class: 'heading-container' }, () => {
@@ -83,6 +91,7 @@ export default class MachineSettings extends View {
             this.th('Status')
             this.th('Created At')
             this.th('Turn on/off')
+            this.th('Terminal')
             this.th('Build logs')
             this.th('Mount')
             this.th('Always on')
@@ -108,6 +117,13 @@ export default class MachineSettings extends View {
                   'data-index': index
                 },
                 isOffline ? 'Turn on' : 'Turn off'
+              ))
+              this.td(() => this.button(
+                {
+                  class: 'btn btn-sm icon icon-terminal',
+                  click: 'onTerminal',
+                  'data-index': index
+                }, 'ssh'
               ))
               this.td(() => {
                 this.button(

--- a/lib/views/machine-settings.js
+++ b/lib/views/machine-settings.js
@@ -114,7 +114,7 @@ export default class MachineSettings extends View {
               this.td(machine.team)
               this.td(machine.label)
               this.td(machine.ip)
-              this.td(machine.owner || '')
+              this.td(machine.owner || machine.username || '')
               this.td(machine.provider)
               this.td(MachineStatusText[machine.status.state])
               this.td(machine.createdAt)

--- a/lib/views/machine-settings.js
+++ b/lib/views/machine-settings.js
@@ -3,6 +3,7 @@
 
 import { Emitter, CompositeDisposable } from 'atom'
 import { View } from 'atom-space-pen-views'
+import moment from 'moment'
 
 import { MachineStatusText, MachineStatus } from '../constants'
 
@@ -130,8 +131,17 @@ export default class MachineSettings extends View {
               this.td(machine.ip)
               this.td(machine.owner || machine.username || '')
               this.td(machine.provider)
-              this.td(machine.createdAt)
               this.td(() => this.button(
+              let formats = {
+                sameDay: '[Today] hh:mm:ss',
+                lastDay: '[Yesterday] hh:mm:ss',
+                lastWeek: '[Last] dddd',
+                sameElse: 'MMM Do, YYYY, hh:mm:ss'
+              }
+              let btnCls = isOffline
+                           ? 'btn-info icon-triangle-right'
+                           : 'icon-primitive-square'
+              this.td(moment(machine.createdAt).calendar(null, formats))
                 {
                   class: 'btn btn-sm',
                   click: isOffline ? 'onTurnOn' : 'onTurnOff',

--- a/lib/views/machine-settings.js
+++ b/lib/views/machine-settings.js
@@ -1,6 +1,7 @@
 'use babel'
+/* globals atom */
 
-import { Emitter } from 'atom'
+import { Emitter, CompositeDisposable } from 'atom'
 import { View } from 'atom-space-pen-views'
 
 import { MachineStatusText, MachineStatus } from '../constants'
@@ -9,7 +10,21 @@ export default class MachineSettings extends View {
 
   initialize ({ machines }) {
     this.emitter = new Emitter()
+    this.subscriptions = new CompositeDisposable()
     this.machines = machines
+    this.find('.icon-server').each((i, el) => {
+      this.addStateTooltip(el)
+    })
+  }
+
+  addStateTooltip (el) {
+    this.subscriptions.add(atom.tooltips.add(el, {
+      title: `Machine Status: ${el.dataset.state}`
+    }))
+  }
+
+  destroy () {
+    this.subscriptions.dispose()
   }
 
   onClose () {
@@ -95,7 +110,7 @@ export default class MachineSettings extends View {
             this.th('Ip')
             this.th('Owner')
             this.th('Provider')
-            this.th('Status')
+            // this.th('Status')
             this.th('Created At')
             this.th('Turn on/off')
             this.th('Terminal')
@@ -115,7 +130,6 @@ export default class MachineSettings extends View {
               this.td(machine.ip)
               this.td(machine.owner || machine.username || '')
               this.td(machine.provider)
-              this.td(MachineStatusText[machine.status.state])
               this.td(machine.createdAt)
               this.td(() => this.button(
                 {

--- a/lib/views/machine-settings.js
+++ b/lib/views/machine-settings.js
@@ -4,8 +4,10 @@
 import { Emitter, CompositeDisposable } from 'atom'
 import { View } from 'atom-space-pen-views'
 import moment from 'moment'
+import debug from 'debug'
 
 import { MachineStatusText, MachineStatus } from '../constants'
+const log = debug('machine-settings:log')
 
 export default class MachineSettings extends View {
 
@@ -122,16 +124,20 @@ export default class MachineSettings extends View {
         })
         this.tbody(() => {
           machines.forEach((machine, index) => {
-            this.tr(() => {
-              const isOffline = machine.status === MachineStatus.Offline
-              // this.td(machine.id)
-              this.td(machine.alias)
+            let state = MachineStatusText[machine.status.state] || ''
+            this.tr({
+              class: `${state.toLowerCase()}`
+            }, () => {
+              const isOffline = machine.status.state === MachineStatus.Offline
+              this.td({
+                class: 'icon icon-server',
+                'data-state': state
+              }, machine.alias)
               this.td(machine.team)
               this.td(machine.label)
               this.td(machine.ip)
               this.td(machine.owner || machine.username || '')
               this.td(machine.provider)
-              this.td(() => this.button(
               let formats = {
                 sameDay: '[Today] hh:mm:ss',
                 lastDay: '[Yesterday] hh:mm:ss',
@@ -142,21 +148,22 @@ export default class MachineSettings extends View {
                            ? 'btn-info icon-triangle-right'
                            : 'icon-primitive-square'
               this.td(moment(machine.createdAt).calendar(null, formats))
+              this.td({ class: 'centered' }, () => this.button(
                 {
-                  class: 'btn btn-sm',
+                  class: `btn btn-sm icon ${btnCls}`,
                   click: isOffline ? 'onTurnOn' : 'onTurnOff',
                   'data-index': index
                 },
                 isOffline ? 'Turn on' : 'Turn off'
               ))
-              this.td(() => this.button(
+              this.td({ class: 'centered' }, () => this.button(
                 {
                   class: 'btn btn-sm icon icon-terminal',
                   click: 'onTerminal',
                   'data-index': index
                 }, 'ssh'
               ))
-              this.td(() => {
+              this.td({ class: 'centered' }, () => {
                 this.button(
                   {
                     class: 'btn btn-sm',
@@ -166,7 +173,7 @@ export default class MachineSettings extends View {
                   'Logs…'
                 )
               })
-              this.td(() => this.button(
+              this.td({ class: 'centered' }, () => this.button(
                 {
                   class: 'btn btn-sm',
                   click: 'onMount',

--- a/lib/views/machine-settings.js
+++ b/lib/views/machine-settings.js
@@ -16,6 +16,10 @@ export default class MachineSettings extends View {
     this.emitter.emit('machine-settings:close')
   }
 
+  onReload () {
+    this.emitter.emit('machine-settings:reload')
+  }
+
   onMount (event, element) {
     const machine = this.machines[element.data('index')]
 
@@ -73,10 +77,14 @@ export default class MachineSettings extends View {
     this.section({ class: 'section machine-settings' }, () => {
       this.div({ class: 'heading-container' }, () => {
         this.div({ class: 'section-heading' }, 'Machines')
-        this.button(
-          { class: 'btn btn-sm icon icon-x', click: 'onClose' },
-          'Close'
-        )
+        this.button({
+          class: 'btn btn-sm icon icon-sync',
+          click: 'onReload'
+        }, 'Reload')
+        this.button({
+          class: 'btn btn-sm icon icon-x',
+          click: 'onClose'
+        }, 'Close')
       })
       this.table({ class: 'table text' }, () => {
         this.thead(() => {

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -12,7 +12,7 @@ export default class StatusBarIcon extends View {
 
   static content () {
     this.div({
-      class: 'inline-block kd-statusbar-icon'
+      class: 'inline-block kd-statusbar-icon loading'
     }, () => {
       this.raw(Icons.statusBar)
       this.span({
@@ -38,6 +38,8 @@ export default class StatusBarIcon extends View {
           this.setTooltip(prompt)
         }, 2000)
         this.element.classList.add('good')
+        this.element.classList.remove('loading')
+        this.setLoadingMessage()
       } else {
         this.setTooltip(prompt, true)
         this.element.classList.remove('good')

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -1,10 +1,21 @@
 'use babel'
 /* globals atom */
 
+import debug from 'debug'
 import { View } from 'atom-space-pen-views'
 import { Icons } from '../../assets/svgs'
 import KDHelpView from './kd-help-view'
+import CommandCenterView from './command-center'
 import KD from '../kd-states'
+
+const log = debug('statusbar:log')
+
+const success = {
+  NOT_INSTALLED: 'kd installed…',
+  NOT_LOGGEDIN: 'Logged in…',
+  DAEMON_NOT_INSTALLED: 'daemon is installed',
+  DAEMON_STOPPED: 'daemon is running'
+}
 
 let lastPrompt, wasSticky
 
@@ -23,27 +34,26 @@ export default class StatusBarIcon extends View {
   }
 
   attached (event) {
-    this.succeeded = []
     /* to give statusbar sometime to put other
        tiles installed by other packages */
     setTimeout(() => { this.init() }, 1000)
   }
 
   init () {
-    this.setTooltip(null, true)
+    KD.emitter.on('kd-state-all-good', () => {
+      setTimeout(() => {
+        this.setTooltip('command-center')
+        this.setLoadingMessage()
+        this.element.classList.remove('loading')
+      }, 2000)
+      this.element.classList.add('good')
+    })
 
     KD.emitter.on('kd-state', prompt => {
-      if (prompt === 'ALL_GOOD') {
-        setTimeout(() => {
-          this.setTooltip(prompt)
-        }, 2000)
-        this.element.classList.add('good')
-        this.element.classList.remove('loading')
-        this.setLoadingMessage()
-      } else {
-        this.setTooltip(prompt, true)
-        this.element.classList.remove('good')
-      }
+      this.element.classList.remove('good')
+      this.element.classList.remove('loading')
+      this.setTooltip(prompt, true)
+      this.setLoadingMessage()
     })
 
     KD.emitter.on('kd-state-loading', message => {
@@ -57,8 +67,7 @@ export default class StatusBarIcon extends View {
     })
 
     KD.emitter.on('kd-state-success', prompt => {
-      this.succeeded.push(prompt)
-      this.setTooltip(null, true, true)
+      this.setLoadingMessage(success[prompt])
     })
   }
 
@@ -75,11 +84,7 @@ export default class StatusBarIcon extends View {
       this.clearDisposable()
     }
 
-    let item = new KDHelpView({
-      prompt: prompt,
-      mini: true,
-      succeeded: this.succeeded
-    })
+    let item = this.getItem(prompt)
     let trigger = sticky ? 'manual' : 'click'
 
     this.disposable = atom.tooltips.add(this, {
@@ -90,6 +95,24 @@ export default class StatusBarIcon extends View {
 
     lastPrompt = prompt
     wasSticky = sticky
+  }
+
+  getItem (prompt) {
+    let item
+    if (prompt === 'command-center') {
+      log('command-center opened')
+      item = new CommandCenterView()
+    } else {
+      log('help-view opened')
+      item = new KDHelpView({
+        prompt: prompt,
+        mini: true
+      })
+      item.emitter.on('help-view-close-clicked', () => {
+        this.clearDisposable()
+      })
+    }
+    return item
   }
 
   detached () {

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -15,9 +15,10 @@ export default class StatusBarIcon extends View {
       class: 'inline-block kd-statusbar-icon'
     }, () => {
       this.raw(Icons.statusBar)
-      this.raw(`
-        <span id='loading-message' class='inline-block loading-message'></span>
-      `)
+      this.span({
+        outlet: 'message',
+        class: 'inline-block loading-message'
+      }, 'Initializing…')
     })
   }
 
@@ -60,7 +61,7 @@ export default class StatusBarIcon extends View {
   }
 
   setLoadingMessage (message) {
-    this.find('#loading-message').html(message)
+    this.message.html(message)
   }
 
   setTooltip (prompt, sticky, force) {

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -83,7 +83,6 @@ export default class StatusBarIcon extends View {
     let trigger = sticky ? 'manual' : 'click'
 
     this.disposable = atom.tooltips.add(this, {
-      title: 'This is a tooltip',
       trigger: trigger,
       class: 'kd-statusbar-tooltip',
       item: item

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -114,10 +114,10 @@ export default class StatusBarIcon extends View {
         prompt: prompt,
         mini: true
       })
-      item.emitter.on('help-view-close-clicked', () => {
-        this.clearDisposable()
-      })
     }
+    item.emitter.on('help-view-close-clicked', () => {
+      this.clearDisposable()
+    })
     return item
   }
 

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -23,7 +23,8 @@ export default class StatusBarIcon extends View {
 
   static content () {
     this.div({
-      class: 'inline-block kd-statusbar-icon loading'
+      class: 'inline-block kd-statusbar-icon loading',
+      click: 'click'
     }, () => {
       this.raw(Icons.statusBar)
       this.span({
@@ -95,6 +96,11 @@ export default class StatusBarIcon extends View {
 
     lastPrompt = prompt
     wasSticky = sticky
+  }
+
+  click () {
+    if (this.disposable) { return }
+    this.setTooltip(lastPrompt, wasSticky, true)
   }
 
   getItem (prompt) {

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -34,6 +34,10 @@ export default class StatusBarIcon extends View {
     })
   }
 
+  initialize ({ callback }) {
+    this.callback = callback
+  }
+
   attached (event) {
     /* to give statusbar sometime to put other
        tiles installed by other packages */
@@ -108,6 +112,9 @@ export default class StatusBarIcon extends View {
     if (prompt === 'command-center') {
       log('command-center opened')
       item = new CommandCenterView()
+      item.emitter.on('command-center:button-clicked', (target) => {
+        this.callback(`show${target}`)
+      })
     } else {
       log('help-view opened')
       item = new KDHelpView({

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -51,7 +51,7 @@ export default class StatusBarIcon extends View {
 
     KD.emitter.on('kd-state-loading-finished', () => {
       this.element.classList.remove('loading')
-      this.setLoadingMessage('')
+      this.setLoadingMessage()
     })
 
     KD.emitter.on('kd-state-success', prompt => {
@@ -60,7 +60,7 @@ export default class StatusBarIcon extends View {
     })
   }
 
-  setLoadingMessage (message) {
+  setLoadingMessage (message = '') {
     this.message.html(message)
   }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "debug": "^2.6.1",
     "electron-json-storage": "^3.0.1",
     "execa": "^0.6.0",
-    "kd.js": "^1.1.30"
+    "kd.js": "^1.1.30",
+    "moment": "^2.18.1"
   },
   "devDependencies": {
     "eslint": "^3.15.0",

--- a/styles/kd.less
+++ b/styles/kd.less
@@ -75,9 +75,29 @@ status-bar .status-bar-right .kd-statusbar-icon {
 }
 
 .machine-settings {
+  max-height: 33vh;
+  overflow: auto;
   .table {
     td, th {
       border-color: @tab-border-color;
+      vertical-align: inherit;
+    }
+    tr {
+      &.offline {
+        color: @text-color-subtle;
+        &:hover {
+          color: @text-color;
+        }
+      }
+      &.online,
+      &.connected {
+        td.icon:before {
+          color: @text-color-success;
+        }
+      }
+      &:hover {
+        background: @background-color-highlight;
+      }
     }
   }
 

--- a/styles/kd.less
+++ b/styles/kd.less
@@ -95,6 +95,26 @@ status-bar .status-bar-right .kd-statusbar-icon {
   }
 }
 
+.command-center {
+  .icon-check {
+    line-height: 1.5em;
+  }
+  .text {
+    font-size: .9em;
+    line-height: 1.4em;
+    border: 1px solid @inset-panel-border-color;
+  }
+  .buttons {
+    display: flex;
+    align-items: flex-start;
+    margin: 20px 0;
+    button {
+      flex: 0 0 auto;
+      margin-right: 10px;
+    }
+  }
+}
+
 .centered {
   text-align: center;
 }

--- a/styles/kd.less
+++ b/styles/kd.less
@@ -12,7 +12,7 @@
 
 status-bar .status-bar-right .kd-statusbar-icon {
   svg {
-    margin-top: 7px;
+    margin-top: 8px;
     width: 14px;
     height: 14px;
     path {
@@ -35,6 +35,7 @@ status-bar .status-bar-right .kd-statusbar-icon {
 
     .loading-message {
       display: inline-block;
+      padding-left: 5px;
     }
   }
 

--- a/styles/kd.less
+++ b/styles/kd.less
@@ -86,6 +86,12 @@ status-bar .status-bar-right .kd-statusbar-icon {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    div {
+      flex: 1 1 auto;
+    }
+    button {
+      flex: 0 0 auto;
+    }
   }
 }
 


### PR DESCRIPTION
 - helpview - command center (dashboard) separation
 - machine settings `run in terminal` button added
   - `kd ssh <machine>` as the initial command should still be implemented
 - inital system checks taken from the tooltip to status bar
 - close buttons for the tooltip views
 - various minor fixes