### PR TITLE
Start using prettier for code formatting

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,3 +17,7 @@ rules:
   comma-dangle:
     - error
     - only-multiline
+
+  space-before-function-paren:
+    - error
+    - never

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,13 +4,13 @@ export default {
   localBasePath: {
     type: 'string',
     description: 'Local base path for mounting machines',
-    default: `${require('os').homedir()}/koding`
+    default: `${require('os').homedir()}/koding`,
   },
   kdBinaryPath: {
     type: 'string',
     description: `If you have installed <code>kd</code>
                   somewhere other than the default installation path,
                   you can enter the installation path here.`,
-    default: '/usr/local/bin/kd'
-  }
+    default: '/usr/local/bin/kd',
+  },
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,20 +1,15 @@
 'use babel'
 
-export const MachineStatusText = [
-  null,
-  'Offline',
-  'Online',
-  'Connected'
-]
+export const MachineStatusText = [null, 'Offline', 'Online', 'Connected']
 
 export const MachineStatus = {
   Offline: 1,
   Online: 2,
-  Connected: 3
+  Connected: 3,
 }
 
 export const IconType = {
   Directory: 'icon-file-directory',
   Repo: 'icon-repo',
-  Mount: 'icon-mirror'
+  Mount: 'icon-mirror',
 }

--- a/lib/controllers/storage-controller.js
+++ b/lib/controllers/storage-controller.js
@@ -4,7 +4,7 @@ import Storage from '../models/storage'
 
 export default {
   storages: {},
-  make (deserializer) {
+  make(deserializer) {
     if (this.storages[deserializer]) {
       return this.storages[deserializer]
     }
@@ -13,5 +13,5 @@ export default {
     this.storages[deserializer] = storage
 
     return storage
-  }
+  },
 }

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -20,7 +20,7 @@ const log = debug('kd-controller:log')
 const error = debug('kd:err')
 
 export default class KDController extends kd.Object {
-  constructor (serializedState = {}) {
+  constructor(serializedState = {}) {
     super({}, serializedState)
     KD.init()
 
@@ -28,25 +28,25 @@ export default class KDController extends kd.Object {
     this.mountPanel = null
   }
 
-  showLoading (message, duration) {
+  showLoading(message, duration) {
     KD.emitter.emit('kd-state-loading', message)
     if (duration) {
       setTimeout(this.bound('hideLoading'), duration)
     }
   }
 
-  hideLoading () {
+  hideLoading() {
     KD.emitter.emit('kd-state-loading-finished')
   }
 
-  showPrompt (prompts, callback) {
+  showPrompt(prompts, callback) {
     let view = new PromptView(prompts)
 
     let panel = atom.workspace.addModalPanel({
       className: 'kd-loading-modal',
       item: view,
       visible: true,
-      priority: 201
+      priority: 201,
     })
     view.emitter.on('prompt-given', userInputs => {
       callback(null, userInputs)
@@ -57,31 +57,31 @@ export default class KDController extends kd.Object {
     return panel
   }
 
-  _err (e) {
+  _err(e) {
     this.hideLoading()
 
     atom.notifications.addFatalError(`kd: ${e}`, {
       dismissable: true,
-      stack: e.stack
+      stack: e.stack,
     })
 
     error(e)
   }
 
-  _showSelector (items, selector) {
+  _showSelector(items, selector) {
     this.hideLoading()
     selector.getItem().setItems(items)
     selector.getItem().attached()
     selector.show()
   }
 
-  hideSelectors () {
+  hideSelectors() {
     this.teamSelector && this.teamSelector.hide()
     this.machineSelector && this.machineSelector.hide()
     this.mountSelector && this.mountSelector.hide()
   }
 
-  showTeamsSelector (teams, options = {}) {
+  showTeamsSelector(teams, options = {}) {
     if (this.teamSelector) {
       return this._showSelector(teams, this.teamSelector)
     }
@@ -91,7 +91,7 @@ export default class KDController extends kd.Object {
       className: 'kd-team-selector',
       item: view,
       visible: true,
-      priority: 201
+      priority: 201,
     })
     view.emitter.on('teamSelector-cancelled', event => {
       this.teamSelector.hide()
@@ -105,7 +105,7 @@ export default class KDController extends kd.Object {
     return teams
   }
 
-  async showTeams () {
+  async showTeams() {
     log('showTeams')
     this.showLoading('Loading teams…')
 
@@ -113,7 +113,9 @@ export default class KDController extends kd.Object {
     try {
       teams = await getTeams()
       this.getData().teams = teams
-    } catch (e) { return this._err(e) }
+    } catch (e) {
+      return this._err(e)
+    }
 
     this.showLoading('Selecting team…')
     this.showTeamsSelector(teams, {
@@ -121,11 +123,11 @@ export default class KDController extends kd.Object {
         this.getData().team = team
         this.showMachines(team.slug)
       },
-      onCancel: this.bound('hideLoading')
+      onCancel: this.bound('hideLoading'),
     })
   }
 
-  destroyPanel (type) {
+  destroyPanel(type) {
     const panel = this[`${type}Panel`]
 
     panel && panel.destroy()
@@ -133,7 +135,7 @@ export default class KDController extends kd.Object {
     this[`${type}Panel`] = null
   }
 
-  showMachineSettingsView (machines, options = {}) {
+  showMachineSettingsView(machines, options = {}) {
     this.machinePanel = atom.workspace.addBottomPanel({
       className: 'kd-machine-selector',
       item: new MachineSettings({
@@ -141,11 +143,11 @@ export default class KDController extends kd.Object {
         options,
       }),
       visible: true,
-      priority: 201
+      priority: 201,
     })
   }
 
-  async showMachines (team = null, reload = false, filterValue = '') {
+  async showMachines(team = null, reload = false, filterValue = '') {
     log('show machine settings')
     this.showLoading('Loading machines…')
 
@@ -154,7 +156,9 @@ export default class KDController extends kd.Object {
       try {
         machines = await getMachines(team)
         this.getData().machines = machines
-      } catch (e) { return this._err(e) }
+      } catch (e) {
+        return this._err(e)
+      }
     }
 
     this.hideLoading()
@@ -174,15 +178,15 @@ export default class KDController extends kd.Object {
       onPowerChange: this.bound('setPowerState'),
       onTerminal: this.bound('openTerminal'),
       onMount: this.bound('onMount'),
-      onCancel: this.bound('hideLoading')
+      onCancel: this.bound('hideLoading'),
     })
   }
 
-  setAlwaysOn ({ machine, state }) {
+  setAlwaysOn({ machine, state }) {
     log('set always on not implemented yet', { state })
   }
 
-  setPowerState ({ machine, state }) {
+  setPowerState({ machine, state }) {
     const cmd = state ? 'start' : 'stop'
 
     this.showLoading(`${state ? 'Starting' : 'Stopping'} machine…`)
@@ -196,36 +200,35 @@ export default class KDController extends kd.Object {
       .catch(err => {
         this.hideLoading()
         atom.notifications.addError(err.message, {
-          stack: err.stack ? err.stack : null
+          stack: err.stack ? err.stack : null,
         })
       })
   }
 
-  onMount ({ machine }) {
+  onMount({ machine }) {
     this.getData().machine = machine
     this.showMountPrompt(machine)
   }
 
-  openTerminal ({ machine }) {
+  openTerminal({ machine }) {
     // implement initial command based on machine
-    let activeEditor = atom.views.getView(
-      atom.workspace.getActiveTextEditor()
-    )
+    let activeEditor = atom.views.getView(atom.workspace.getActiveTextEditor())
     atom.commands.dispatch(activeEditor, 'atom-terminal:open')
   }
 
-  runMountCmd (machine, options = {}) {
+  runMountCmd(machine, options = {}) {
     const { remote, local, onConfirm, onError } = options
 
     kdRun(['machine', 'mount', remote, local])
       .then(result => {
         onConfirm && onConfirm()
-      }).catch(e => {
+      })
+      .catch(e => {
         onError && onError(e)
       })
   }
 
-  showMountPrompt (machine) {
+  showMountPrompt(machine) {
     const localBasePath = atom.config.get('kd.localBasePath')
     const localPath = `${localBasePath}/${machine.team}/${machine.label}`
     const remotePath = `/home/${machine.owner || machine.username}`
@@ -237,7 +240,9 @@ export default class KDController extends kd.Object {
         panel.destroy()
         this.hideLoading()
 
-        if (err) { return }
+        if (err) {
+          return
+        }
 
         const { localPath, remotePath } = inputs
         const remoteAddress = `${machine.id}:${remotePath}`
@@ -256,15 +261,15 @@ export default class KDController extends kd.Object {
           onError: err => {
             this.hideLoading()
             atom.notifications.addError(getMountError(), {
-              stack: err.stack
+              stack: err.stack,
             })
-          }
+          },
         })
-      }
+      },
     })
   }
 
-  showMountSettingsView (mounts, machines, options = {}) {
+  showMountSettingsView(mounts, machines, options = {}) {
     this.destroyPanel('mount')
     this.mountPanel = atom.workspace.addBottomPanel({
       className: 'kd-machine-selector',
@@ -273,15 +278,15 @@ export default class KDController extends kd.Object {
         machines,
         options: {
           ...options,
-          onClose: () => this.destroyPanel('mount')
-        }
+          onClose: () => this.destroyPanel('mount'),
+        },
       }),
       visible: true,
-      priority: 201
+      priority: 201,
     })
   }
 
-  async showMounts () {
+  async showMounts() {
     log('show mounts settings')
     this.showLoading('Loading mounts…')
 
@@ -292,7 +297,9 @@ export default class KDController extends kd.Object {
       this.getData().mounts = mounts
       this.getData().machines = machines
       setMountIcons(mounts)
-    } catch (e) { return this._err(e) }
+    } catch (e) {
+      return this._err(e)
+    }
 
     this.hideLoading()
 
@@ -340,21 +347,23 @@ export default class KDController extends kd.Object {
               { stack: err.stack }
             )
           })
-      }
+      },
     })
   }
 
-  consumeStatusBar (statusBar) {
+  consumeStatusBar(statusBar) {
     this.statusBarItem = new StatusBarIcon({
-      callback: (method) => { this[method] && this[method]() }
+      callback: method => {
+        this[method] && this[method]()
+      },
     })
     this.statusBarTile = statusBar.addRightTile({
       item: this.statusBarItem,
-      priority: 100
+      priority: 100,
     })
   }
 
-  destroy () {
+  destroy() {
     this.statusBarTile.destroy()
     this.statusBarItem.destroy()
     this.statusBarTile = null
@@ -372,19 +381,17 @@ const getMountedMessage = () =>
 
 const getMountError = () => `Machine could not be mounted, rolling back…`
 
-const makePrompts = (remote, local) => (
-  [
-    {
-      name: 'localPath',
-      title: 'Local path:',
-      defaultValue: local,
-      placeholder: local
-    },
-    {
-      name: 'remotePath',
-      title: 'Remote path:',
-      defaultValue: remote,
-      placeholder: remote
-    }
-  ]
-)
+const makePrompts = (remote, local) => [
+  {
+    name: 'localPath',
+    title: 'Local path:',
+    defaultValue: local,
+    placeholder: local,
+  },
+  {
+    name: 'remotePath',
+    title: 'Remote path:',
+    defaultValue: remote,
+    placeholder: remote,
+  },
+]

--- a/lib/kd-states.js
+++ b/lib/kd-states.js
@@ -13,17 +13,17 @@ const STATES = {
   NOT_INSTALLED: 'NOT_INSTALLED',
   DAEMON_NOT_INSTALLED: 'DAEMON_NOT_INSTALLED',
   // DAEMON_STOPPED: 'DAEMON_STOPPED',
-  NOT_LOGGEDIN: 'NOT_LOGGEDIN'
+  NOT_LOGGEDIN: 'NOT_LOGGEDIN',
 }
 
 const checkers = {
   isKDInstalled: {
     state: 'NOT_INSTALLED',
-    fn: execa.bind(this, 'which', [kdPath])
+    fn: execa.bind(this, 'which', [kdPath]),
   },
   isDaemonInstalled: {
     state: 'DAEMON_NOT_INSTALLED',
-    fn: execa.bind(this, kdPath, ['status'])
+    fn: execa.bind(this, kdPath, ['status']),
   },
   // isDaemonStopped: {
   //   state: 'DAEMON_STOPPED',
@@ -31,8 +31,8 @@ const checkers = {
   // },
   isLoggedIn: {
     state: 'NOT_LOGGEDIN',
-    fn: execa.bind(this, kdPath, ['team', 'show'])
-  }
+    fn: execa.bind(this, kdPath, ['team', 'show']),
+  },
 }
 
 const promptOrder = Object.keys(STATES)
@@ -41,7 +41,7 @@ const INITIAL_DELAY = 5000
 
 const emitter = new Emitter()
 
-function check (prompt) {
+function check(prompt) {
   if (!prompt) {
     log(prompt, 'no prompt')
     prompt = promptOrder[0]
@@ -53,26 +53,28 @@ function check (prompt) {
     return null
   }
 
-  checker().then(res => {
-    log(prompt, 'all good')
-    emitter.emit('kd-state-success', prompt)
-    let nextPrompt = getNextPrompt(prompt)
-    if (nextPrompt) {
-      check(nextPrompt)
-    } else {
-      log('kd-is-in-good-shape')
-      emitter.emit('kd-state-all-good')
-      emitter.emit('ready')
-    }
-  }).catch(err => {
-    emitter.emit('kd-state', prompt)
-    error(err)
-    log(prompt, 'checking again')
-    setTimeout(check.bind(this, prompt), DELAY)
-  })
+  checker()
+    .then(res => {
+      log(prompt, 'all good')
+      emitter.emit('kd-state-success', prompt)
+      let nextPrompt = getNextPrompt(prompt)
+      if (nextPrompt) {
+        check(nextPrompt)
+      } else {
+        log('kd-is-in-good-shape')
+        emitter.emit('kd-state-all-good')
+        emitter.emit('ready')
+      }
+    })
+    .catch(err => {
+      emitter.emit('kd-state', prompt)
+      error(err)
+      log(prompt, 'checking again')
+      setTimeout(check.bind(this, prompt), DELAY)
+    })
 }
 
-function getNextPrompt (prompt) {
+function getNextPrompt(prompt) {
   let index = promptOrder.indexOf(prompt)
   let next = null
 
@@ -82,16 +84,18 @@ function getNextPrompt (prompt) {
   return next
 }
 
-function getCheckerFn (kdState) {
+function getCheckerFn(kdState) {
   let checkerFn
   for (let key in checkers) {
     let { state, fn } = checkers[key]
-    if (kdState === state) { checkerFn = fn }
+    if (kdState === state) {
+      checkerFn = fn
+    }
   }
   return checkerFn
 }
 
-function init () {
+function init() {
   /* this timeout is for some reason necessary
      otherwise we get an ENOENT error */
   setTimeout(() => {
@@ -105,5 +109,5 @@ export default {
   checkers,
   getCheckerFn,
   emitter,
-  check
+  check,
 }

--- a/lib/kd.js
+++ b/lib/kd.js
@@ -14,62 +14,73 @@ const log = debug('kd:log')
 const error = debug('kd:err')
 
 export default {
-
   kdController: null,
 
   config: config,
 
-  activate (state) {
+  activate(state) {
     log('kd activated!', state)
     this.subscriptions = new CompositeDisposable()
     this.storage = StorageController.make('KDController')
 
     this.kdController = new KDController(state)
 
-    this.storage.deserialize(state).then(data => {
-      this.kdController.setData(data)
-      this.kdController.consumeStatusBar(this.statusBarRegistry)
+    this.storage
+      .deserialize(state)
+      .then(data => {
+        this.kdController.setData(data)
+        this.kdController.consumeStatusBar(this.statusBarRegistry)
 
-      if (data.mounts) {
-        setMountIcons(data.mounts)
-      }
-    }).catch(err => error('can not deserialize', err))
+        if (data.mounts) {
+          setMountIcons(data.mounts)
+        }
+      })
+      .catch(err => error('can not deserialize', err))
 
     KD.emitter.on('ready', this.bindEvents.bind(this))
 
     checkAtomDeps()
   },
 
-  bindEvents () {
+  bindEvents() {
     let controller = this.kdController
-    this.subscriptions.add(atom.commands.add('atom-workspace', {
-      'kd:teams': () => { controller.showTeams() },
-      'kd:machines': () => { controller.showMachines() },
-      'kd:mounts': () => { controller.showMounts() },
-      'kd:terminal': () => {
-        controller.openTerminal({ machine: controller.getData().machine })
-      },
-      'kd:dashboard': () => { controller.statusBarItem.trigger('click') }
-    }))
+    this.subscriptions.add(
+      atom.commands.add('atom-workspace', {
+        'kd:teams': () => {
+          controller.showTeams()
+        },
+        'kd:machines': () => {
+          controller.showMachines()
+        },
+        'kd:mounts': () => {
+          controller.showMounts()
+        },
+        'kd:terminal': () => {
+          controller.openTerminal({ machine: controller.getData().machine })
+        },
+        'kd:dashboard': () => {
+          controller.statusBarItem.trigger('click')
+        },
+      })
+    )
   },
 
-  serialize () {
+  serialize() {
     return this.storage.serialize(this.kdController.getData())
   },
 
-  deactivate () {
+  deactivate() {
     this.statusBarRegistry = null
     this.subscriptions.dispose()
     this.kdController.destroy()
   },
 
-  resetStorage () {
+  resetStorage() {
     this.storage.reset()
     this.kdController.reset()
   },
 
-  consumeStatusBar (statusBar) {
+  consumeStatusBar(statusBar) {
     this.statusBarRegistry = statusBar
-  }
-
+  },
 }

--- a/lib/models/storage.js
+++ b/lib/models/storage.js
@@ -10,13 +10,13 @@ const error = debug('storage:error')
 const STORAGE_KEY = 'kd-serializer'
 
 export default class Storage extends kd.Object {
-  constructor (options = {}, data = null) {
+  constructor(options = {}, data = null) {
     options.storageKey = options.storageKey || STORAGE_KEY
     options.deserializer = options.deserializer || `deserializer:${Date.now()}`
     super(options, data)
   }
 
-  deserialize (state) {
+  deserialize(state) {
     log('deserializing')
     if (state.deserializer === this.getOption('deserializer') && state.data) {
       log('given state already has data, storage not used', state)
@@ -47,11 +47,11 @@ export default class Storage extends kd.Object {
     })
   }
 
-  serialize (data) {
+  serialize(data) {
     const { deserializer, storageKey } = this.getOptions()
     const state = {
       deserializer,
-      data: data || this.getData()
+      data: data || this.getData(),
     }
 
     log('serializing', state)
@@ -60,7 +60,7 @@ export default class Storage extends kd.Object {
     return data
   }
 
-  reset () {
+  reset() {
     this.serialize({})
     log('storage cleared')
   }

--- a/lib/utils/check-atom-deps.js
+++ b/lib/utils/check-atom-deps.js
@@ -3,7 +3,7 @@
 import { remote } from 'electron'
 import { install as atomPackageDepsInstall } from 'atom-package-deps'
 
-export default function checkAtomDeps () {
+export default function checkAtomDeps() {
   // Workaround for restoring multiple Atom windows. This prevents having all
   // the windows trying to install the deps at the same time - often
   // clobbering each other's install.

--- a/lib/utils/format-date.js
+++ b/lib/utils/format-date.js
@@ -9,6 +9,6 @@ const formats = {
   sameElse: 'MMM Do, YYYY',
 }
 
-export default function formatDate (date) {
+export default function formatDate(date) {
   return moment(date).calendar(null, formats)
 }

--- a/lib/utils/get-kd-path.js
+++ b/lib/utils/get-kd-path.js
@@ -1,6 +1,6 @@
 'use babel'
 /* globals atom */
 
-export default function getKdPath (commands) { 
+export default function getKdPath(commands) {
   return atom.config.get('kd.kdBinaryPath') || 'kd'
 }

--- a/lib/utils/get-keybinding.js
+++ b/lib/utils/get-keybinding.js
@@ -3,7 +3,7 @@
 
 import getPlatform from './get-platform'
 
-export default function getKeybinding (command, all = false) {
+export default function getKeybinding(command, all = false) {
   const commandPaletteKeyBindings = atom.keymaps.findKeyBindings({ command })
   let keybinding
   commandPaletteKeyBindings.forEach(binding => {

--- a/lib/utils/get-machines.js
+++ b/lib/utils/get-machines.js
@@ -2,13 +2,12 @@
 
 import kd from './kd-run'
 
-export default function getMachines (team) {
-  return kd('machine list --json')
-    .then(result => {
-      let machines = JSON.parse(result.stdout)
-      if (team) {
-        machines = machines.filter(machine => machine.team === team)
-      }
-      return machines
-    })
+export default function getMachines(team) {
+  return kd('machine list --json').then(result => {
+    let machines = JSON.parse(result.stdout)
+    if (team) {
+      machines = machines.filter(machine => machine.team === team)
+    }
+    return machines
+  })
 }

--- a/lib/utils/get-mount-icon-selector.js
+++ b/lib/utils/get-mount-icon-selector.js
@@ -1,5 +1,5 @@
 'use babel'
 
-export default function getMountIconSelector (mount) {
+export default function getMountIconSelector(mount) {
   return `.tree-view [data-path="${mount.mount.path}"]`
 }

--- a/lib/utils/get-mount-paths.js
+++ b/lib/utils/get-mount-paths.js
@@ -1,5 +1,5 @@
 'use babel'
 
-export default function getMountPaths (mounts = []) {
+export default function getMountPaths(mounts = []) {
   return mounts.map(mount => mount.mount.path)
 }

--- a/lib/utils/get-mounts.js
+++ b/lib/utils/get-mounts.js
@@ -2,18 +2,17 @@
 
 import kd from './kd-run'
 
-export default function getMounts () {
-  return kd('machine mount list --json')
-    .then(result => {
-      let mountsObj = JSON.parse(result.stdout)
-      let mounts = []
-      for (let label in mountsObj) {
-        let machineMounts = mountsObj[label]
-        machineMounts.forEach(mount => {
-          mount.label = label
-          mounts.push(mount)
-        })
-      }
-      return mounts
-    })
+export default function getMounts() {
+  return kd('machine mount list --json').then(result => {
+    let mountsObj = JSON.parse(result.stdout)
+    let mounts = []
+    for (let label in mountsObj) {
+      let machineMounts = mountsObj[label]
+      machineMounts.forEach(mount => {
+        mount.label = label
+        mounts.push(mount)
+      })
+    }
+    return mounts
+  })
 }

--- a/lib/utils/get-platform.js
+++ b/lib/utils/get-platform.js
@@ -1,9 +1,11 @@
 'use babel'
 
-export default function getPlatform () {
+export default function getPlatform() {
   let platform
   document.body.classList.forEach(cl => {
-    if (/^platform-/.test(cl)) { platform = cl }
+    if (/^platform-/.test(cl)) {
+      platform = cl
+    }
   })
   return platform
 }

--- a/lib/utils/get-teams.js
+++ b/lib/utils/get-teams.js
@@ -2,7 +2,6 @@
 
 import kd from './kd-run'
 
-export default function getTeams () {
-  return kd('team list --json')
-    .then(result => JSON.parse(result.stdout))
+export default function getTeams() {
+  return kd('team list --json').then(result => JSON.parse(result.stdout))
 }

--- a/lib/utils/kd-run.js
+++ b/lib/utils/kd-run.js
@@ -5,7 +5,7 @@ import getKdPath from './get-kd-path'
 
 const kdPath = getKdPath()
 
-export default function runKd (commands) {
+export default function runKd(commands) {
   if (!Array.isArray(commands)) {
     commands = commands.split(' ')
   }

--- a/lib/utils/set-mount-icons.js
+++ b/lib/utils/set-mount-icons.js
@@ -3,11 +3,13 @@
 import getMountIconSelector from './get-mount-icon-selector'
 import { IconType } from '../constants'
 
-export default function setMountIcons (mounts = []) {
+export default function setMountIcons(mounts = []) {
   mounts.forEach(mount => {
     const el = document.querySelector(getMountIconSelector(mount))
 
-    if (!el || el.classList.contains(IconType.Mount)) { return }
+    if (!el || el.classList.contains(IconType.Mount)) {
+      return
+    }
 
     el.classList.remove(IconType.Repo)
     el.classList.remove(IconType.Directory)

--- a/lib/utils/show-tree-view.js
+++ b/lib/utils/show-tree-view.js
@@ -3,7 +3,7 @@
 
 const CMD_TREE_VIEW_SHOW = 'tree-view:show'
 
-export default function showTreeView () {
+export default function showTreeView() {
   const activeEditor = atom.workspace.getActiveTextEditor()
   const activeView = atom.views.getView(activeEditor)
 

--- a/lib/views/atom-input.js
+++ b/lib/views/atom-input.js
@@ -21,14 +21,14 @@ import ReactDOM from 'react-dom'
 * An input field rendered as an <atom-text-editor mini />.
 */
 export default class AtomInput extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.state = {
-      value: props.value == null ? props.initialValue : props.value
+      value: props.value == null ? props.initialValue : props.value,
     }
   }
 
-  componentDidMount () {
+  componentDidMount() {
     const disposables = (this._disposables = new CompositeDisposable())
 
     // There does not appear to be any sort of infinite loop where calling
@@ -88,7 +88,7 @@ export default class AtomInput extends React.Component {
     this._updateWidth()
   }
 
-  componentWillReceiveProps (nextProps) {
+  componentWillReceiveProps(nextProps) {
     if (nextProps.disabled !== this.props.disabled) {
       this._updateDisabledState(nextProps.disabled)
     }
@@ -109,11 +109,11 @@ export default class AtomInput extends React.Component {
     }
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate(prevProps, prevState) {
     this._updateWidth(prevProps.width)
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     // Note that destroy() is not part of TextEditor's public API.
     this.getTextEditor().destroy()
 
@@ -123,7 +123,7 @@ export default class AtomInput extends React.Component {
     }
   }
 
-  _updateDisabledState (isDisabled) {
+  _updateDisabledState(isDisabled) {
     // Hack to set TextEditor to read-only mode, per
     // https://github.com/atom/atom/issues/6880
     if (isDisabled) {
@@ -133,7 +133,7 @@ export default class AtomInput extends React.Component {
     }
   }
 
-  render () {
+  render() {
     const { size, unstyled, onClick, onFocus, onBlur } = this.props
 
     const className = classNames(this.props.className, {
@@ -157,36 +157,36 @@ export default class AtomInput extends React.Component {
     )
   }
 
-  getText () {
+  getText() {
     return this.state.value
   }
 
-  setText (text) {
+  setText(text) {
     this.getTextEditor().setText(text)
   }
 
-  getTextEditor () {
+  getTextEditor() {
     return this.getTextEditorElement().getModel()
   }
 
-  onDidChange (callback) {
+  onDidChange(callback) {
     return this.getTextEditor().onDidChange(callback)
   }
 
-  getTextEditorElement () {
+  getTextEditorElement() {
     /* eslint-disable */
     return ReactDOM.findDOMNode(this)
     /* eslint-enable */
   }
 
-  _updateWidth (prevWidth) {
+  _updateWidth(prevWidth) {
     if (this.props.width !== prevWidth) {
       const width = this.props.width == null ? undefined : this.props.width
       this.getTextEditorElement().setWidth(width)
     }
   }
 
-  focus () {
+  focus() {
     this.getTextEditor().moveToEndOfLine()
     this.getTextEditorElement().focus()
   }

--- a/lib/views/command-center.js
+++ b/lib/views/command-center.js
@@ -8,8 +8,7 @@ import getKeybinding from '../utils/get-keybinding'
 const log = debug('command-center:log')
 
 export default class CommandCenterView extends View {
-
-  static content (data = {}) {
+  static content(data = {}) {
     this.div({ class: 'command-center' }, () => {
       this.div({ outlet: 'content' }, () => {
         this.h2(() => {
@@ -17,45 +16,65 @@ export default class CommandCenterView extends View {
           this.text('is up & running')
           this.span({
             class: 'icon icon-x x pull-right',
-            click: 'close'
+            click: 'close',
           })
         })
 
-        this.div({
-          class: 'icon icon-check'
-        }, `The daemon is running.`)
-        this.div({
-          class: 'icon icon-check'
-        }, `You're logged in!`)
+        this.div(
+          {
+            class: 'icon icon-check',
+          },
+          `The daemon is running.`
+        )
+        this.div(
+          {
+            class: 'icon icon-check',
+          },
+          `You're logged in!`
+        )
 
         this.div({ class: 'buttons' }, () => {
-          this.button({
-            click: 'show',
-            class: 'btn btn-sm btn-info icon icon-server' }
-          , 'Machines')
-          this.button({
-            click: 'show',
-            class: 'btn btn-sm icon icon-organization' }
-          , 'Teams')
-          this.button({
-            click: 'show',
-            class: 'btn btn-sm icon icon-mirror' }
-          , 'Mounts')
+          this.button(
+            {
+              click: 'show',
+              class: 'btn btn-sm btn-info icon icon-server',
+            },
+            'Machines'
+          )
+          this.button(
+            {
+              click: 'show',
+              class: 'btn btn-sm icon icon-organization',
+            },
+            'Teams'
+          )
+          this.button(
+            {
+              click: 'show',
+              class: 'btn btn-sm icon icon-mirror',
+            },
+            'Mounts'
+          )
         })
 
-        this.div({
-          class: 'alert text icon icon-question',
-          outlet: 'infobox'
-        }, () => {
-          this.raw(`Now you can open the command palette
+        this.div(
+          {
+            class: 'alert text icon icon-question',
+            outlet: 'infobox',
+          },
+          () => {
+            this.raw(
+              `Now you can open the command palette
                    (<code>!!!!</code>) and type <code>kd</code>
-                   to see the available commands.`)
-        })
+                   to see the available commands.`
+            )
+          }
+        )
       })
     })
   }
 
-  initialize () {
+  initialize() {
     this.emitter = new Emitter()
     setTimeout(() => {
       let binding = getKeybinding('command-palette:toggle')
@@ -63,15 +82,14 @@ export default class CommandCenterView extends View {
     }, 1000)
   }
 
-  close (event) {
+  close(event) {
     this.emitter.emit('help-view-close-clicked')
   }
 
-  show (event) {
+  show(event) {
     let target = event.target.innerHTML
     log(`show${target}`)
     this.emitter.emit(`command-center:button-clicked`, target)
     this.close()
   }
-
 }

--- a/lib/views/kd-help-view.js
+++ b/lib/views/kd-help-view.js
@@ -11,29 +11,29 @@ const descriptions = {
     description: `
       Please open a terminal window and install it with the following commands
       and come back once done. (mac/linux only)
-    `
+    `,
   },
   NOT_LOGGEDIN: {
     title: 'Login/Register',
     description: `
       You are not logged in, please log in with the following commands and come
       back.
-    `
+    `,
   },
   DAEMON_NOT_INSTALLED: {
     title: 'Daemon is missing',
     description: `
       It seems like the <code>kd</code> binary is installed but its daemon is
       missing, please install it with the following command.
-    `
+    `,
   },
   DAEMON_STOPPED: {
     title: 'Daemon is not running',
     description: `
       <code>kd</code> daemon is not running please run it with the following
       command:
-    `
-  }
+    `,
+  },
 }
 
 const helpers = {
@@ -41,48 +41,45 @@ const helpers = {
     'rm -rf ~/.config/koding',
     'brew tap rjeczalik/kd',
     'brew install kd --devel',
-    'sudo kd daemon install --team &lt;slug&gt; --baseurl https://koding.com'
+    'sudo kd daemon install --team &lt;slug&gt; --baseurl https://koding.com',
   ],
-  NOT_LOGGEDIN: [
-    'kd auth login --team &lt;yourteam&gt;'
-  ],
-  DAEMON_NOT_INSTALLED: [
-    'sudo kd daemon install --team &lt;yourteam&gt;'
-  ],
-  DAEMON_STOPPED: [
-    'sudo kd daemon restart'
-  ]
+  NOT_LOGGEDIN: ['kd auth login --team &lt;yourteam&gt;'],
+  DAEMON_NOT_INSTALLED: ['sudo kd daemon install --team &lt;yourteam&gt;'],
+  DAEMON_STOPPED: ['sudo kd daemon restart'],
 }
 
 export default class KDHelpView extends View {
-
-  static content (data = {}) {
+  static content(data = {}) {
     this.div(() => {
       if (!data.mini) {
-        this.div({ class: 'kd-help-view--logo' }, () => { this.raw(logo) })
+        this.div({ class: 'kd-help-view--logo' }, () => {
+          this.raw(logo)
+        })
       }
       this.div({ outlet: 'content', click: 'click' })
     })
   }
 
-  setData (data = {}) {
+  setData(data = {}) {
     this.__data = data
     return data
   }
 
-  getData () {
+  getData() {
     return this.__data
   }
 
-  initialize (data) {
+  initialize(data) {
     let { prompt } = data
     this.setData(data)
     this.emitter = new Emitter()
-    if (!prompt) { return }
+    if (!prompt) {
+      return
+    }
     this.setContent(prompt)
   }
 
-  setContent (prompt) {
+  setContent(prompt) {
     this.content.html('')
     let commandsHTML = ''
     if (helpers[prompt]) {
@@ -92,16 +89,18 @@ export default class KDHelpView extends View {
         commandsHTML += '<br>'
       }
     }
-    this.content.append(`
+    this.content.append(
+      `
       <h2>${descriptions[prompt].title}
-      <span class='icon icon-x x pull-right'></span></h2>`)
+      <span class='icon icon-x x pull-right'></span></h2>`
+    )
     this.content.append(`<p>${descriptions[prompt].description}</p>`)
     if (commandsHTML) {
       this.content.append(`<pre>${commandsHTML}</pre>`)
     }
   }
 
-  click (event) {
+  click(event) {
     if (event.target.classList.contains('icon-x')) {
       return this.emitter.emit('help-view-close-clicked')
     }
@@ -110,7 +109,7 @@ export default class KDHelpView extends View {
     }
   }
 
-  copyToClipboard (event) {
+  copyToClipboard(event) {
     let el, command
 
     if (event.target.tagName === 'SPAN') {
@@ -124,8 +123,7 @@ export default class KDHelpView extends View {
     atom.clipboard.write(command)
     atom.notifications.add('info', 'Command copied to the clipboard!', {
       icon: 'clippy',
-      description: `\`${command}\``
+      description: `\`${command}\``,
     })
   }
-
 }

--- a/lib/views/loading-view.js
+++ b/lib/views/loading-view.js
@@ -3,11 +3,9 @@
 import { View } from 'atom-space-pen-views'
 
 export default class LoadingView extends View {
-
-  static content (message, icon = 'hourglass') {
+  static content(message, icon = 'hourglass') {
     this.div({ class: `icon icon-${icon}` }, () => {
       this.raw(message)
     })
   }
-
 }

--- a/lib/views/machine-row.js
+++ b/lib/views/machine-row.js
@@ -58,11 +58,7 @@ const MachineRow = ({
         />
       </td>
       <td className="centered">
-        <button
-          className="btn btn-sm"
-          onClick={_onMount}
-          children="Mount…"
-        />
+        <button className="btn btn-sm" onClick={_onMount} children="Mount…" />
       </td>
       <td className="centered">
         <input type="checkbox" onChange={_onAlwaysChange} disabled />

--- a/lib/views/machine-settings.js
+++ b/lib/views/machine-settings.js
@@ -9,60 +9,62 @@ import { render } from 'react-dom'
 import MachinesTable from './machines-table'
 
 export default class MachineSettings extends View {
-  static content ({ machines }) {
+  static content({ machines }) {
     this.section({ class: 'machines-list-container' })
   }
 
-  initialize ({ machines, options }) {
+  initialize({ machines, options }) {
     this.emitter = new Emitter()
     this.subscriptions = new CompositeDisposable()
     this.machines = machines
     this.options = options
   }
 
-  addStateTooltip (el) {
-    this.subscriptions.add(atom.tooltips.add(el, {
-      title: `Machine Status: ${el.dataset.state}`
-    }))
+  addStateTooltip(el) {
+    this.subscriptions.add(
+      atom.tooltips.add(el, {
+        title: `Machine Status: ${el.dataset.state}`,
+      })
+    )
   }
 
-  destroy () {
+  destroy() {
     this.subscriptions.dispose()
   }
 
-  onClose () {
+  onClose() {
     this.options.onClose()
   }
 
-  onReload () {
+  onReload() {
     return this.options.onReload()
   }
 
-  onMount (machine) {
+  onMount(machine) {
     return this.options.onMount({ machine })
   }
 
-  onTurnOn (machine) {
+  onTurnOn(machine) {
     return this.options.onPowerChange({ machine, state: true })
   }
 
-  onTurnOff (machine) {
+  onTurnOff(machine) {
     return this.options.onPowerChange({ machine, state: false })
   }
 
-  onAlwaysOnChange (machine) {
+  onAlwaysOnChange(machine) {
     return this.options.onAlwaysOnChange({ machine })
   }
 
-  onTerminal (machine) {
+  onTerminal(machine) {
     return this.options.onTerminal({ machine })
   }
 
-  attached () {
+  attached() {
     this.renderTable({ machines: this.machines })
   }
 
-  renderTable ({ machines }) {
+  renderTable({ machines }) {
     render(
       <MachinesTable
         machines={machines}

--- a/lib/views/machines-table.js
+++ b/lib/views/machines-table.js
@@ -5,12 +5,12 @@ import TableView from './table-view'
 import MachineRow from './machine-row'
 
 export default class MachinesTable extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.state = { powerProgress: {} }
   }
 
-  getHeadings () {
+  getHeadings() {
     return [
       { label: 'Alias', accessor: 'alias' },
       { label: 'Team', accessor: 'team' },
@@ -26,7 +26,7 @@ export default class MachinesTable extends React.Component {
     ]
   }
 
-  setPowerProgress (machine, state) {
+  setPowerProgress(machine, state) {
     this.setState({
       powerProgress: {
         ...this.state.powerProgress,
@@ -35,9 +35,10 @@ export default class MachinesTable extends React.Component {
     })
   }
 
-  onTurnOn (machine, index) {
+  onTurnOn(machine, index) {
     this.setPowerProgress(machine, true)
-    this.props.onTurnOn(machine, index)
+    this.props
+      .onTurnOn(machine, index)
       .then(() => {
         this.setPowerProgress(machine, false)
       })
@@ -46,9 +47,10 @@ export default class MachinesTable extends React.Component {
       })
   }
 
-  onTurnOff (machine, index) {
+  onTurnOff(machine, index) {
     this.setPowerProgress(machine, true)
-    this.props.onTurnOff(machine, index)
+    this.props
+      .onTurnOff(machine, index)
       .then(() => {
         this.setPowerProgress(machine, false)
       })
@@ -57,7 +59,7 @@ export default class MachinesTable extends React.Component {
       })
   }
 
-  renderRow (machine, index) {
+  renderRow(machine, index) {
     return (
       <MachineRow
         key={index}
@@ -73,7 +75,7 @@ export default class MachinesTable extends React.Component {
     )
   }
 
-  render () {
+  render() {
     const { machines, onClose, onReload } = this.props
 
     return (

--- a/lib/views/mount-row.js
+++ b/lib/views/mount-row.js
@@ -19,9 +19,9 @@ const MountRow = ({
 
   if (isOffline(mount)) {
     return (
-      <tr className='cursor-pointer' onClick={_onShowMachine}>
+      <tr className="cursor-pointer" onClick={_onShowMachine}>
         <td>{mount.label}</td>
-        <td colSpan='4'>
+        <td colSpan="4">
           Mounted machine is offline.
           Close this window and run <strong>kd:machines</strong> to turn it on.
         </td>
@@ -59,16 +59,9 @@ const BrokenMount = () => (
 
 const OpenCell = ({ onOpen, onNewWindow }) => (
   <td>
-    <div className='btn-group btn-group-sm'>
-      <button
-        className='btn'
-        onClick={onOpen}
-        children='Open'
-      />
-      <button
-        className='btn icon icon-link-external'
-        onClick={onNewWindow}
-      />
+    <div className="btn-group btn-group-sm">
+      <button className="btn" onClick={onOpen} children="Open" />
+      <button className="btn icon icon-link-external" onClick={onNewWindow} />
     </div>
   </td>
 )
@@ -82,9 +75,9 @@ const MountAction = ({ mount, onUnmount }) => {
   return (
     <td>
       <button
-        className='btn btn-sm btn-error'
+        className="btn btn-sm btn-error"
         onClick={onUnmount}
-        children='Unmount'
+        children="Unmount"
         disabled={isOffline(mount)}
       />
     </td>

--- a/lib/views/mount-settings.js
+++ b/lib/views/mount-settings.js
@@ -9,48 +9,48 @@ import { find } from 'lodash'
 import MountsTable from './mounts-table'
 
 export default class MountSettings extends View {
-  static content ({ mounts }) {
+  static content({ mounts }) {
     this.section({ class: 'machines-list-container' })
   }
 
-  initialize ({ mounts, machines, options }) {
+  initialize({ mounts, machines, options }) {
     this.emitter = new Emitter()
     this.options = options
     this.mounts = mounts.map(mount => ({
       ...mount,
-      machine: find(machines, { alias: mount.label })
+      machine: find(machines, { alias: mount.label }),
     }))
   }
 
-  onClose () {
+  onClose() {
     this.options.onClose()
   }
 
-  onReload () {
+  onReload() {
     this.options.onReload()
   }
 
-  onOpen (mount) {
+  onOpen(mount) {
     this.options.onOpen({ mount })
   }
 
-  onNewWindow (mount) {
+  onNewWindow(mount) {
     this.options.onNewWindow({ mount })
   }
 
-  onUnmount (mount) {
+  onUnmount(mount) {
     this.options.onUnmount({ mount })
   }
 
-  onShowMachine (machine) {
+  onShowMachine(machine) {
     this.options.onShowMachine({ machine })
   }
 
-  attached () {
+  attached() {
     this.renderTable({ mounts: this.mounts })
   }
 
-  renderTable ({ mounts }) {
+  renderTable({ mounts }) {
     render(
       <MountsTable
         mounts={mounts}

--- a/lib/views/mounts-table.js
+++ b/lib/views/mounts-table.js
@@ -5,7 +5,7 @@ import TableView from './table-view'
 import MountRow from './mount-row'
 
 export default class MountsTable extends React.Component {
-  getHeadings () {
+  getHeadings() {
     return [
       { label: 'Label', accessor: 'label' },
       { label: 'Local Path', accessor: 'mount.path' },
@@ -15,7 +15,7 @@ export default class MountsTable extends React.Component {
     ]
   }
 
-  renderRow (mount, index) {
+  renderRow(mount, index) {
     return (
       <MountRow
         key={index}
@@ -29,7 +29,7 @@ export default class MountsTable extends React.Component {
     )
   }
 
-  render () {
+  render() {
     const { mounts, onClose, onReload } = this.props
 
     return (

--- a/lib/views/prompt-view.js
+++ b/lib/views/prompt-view.js
@@ -8,7 +8,7 @@ const log = debug('mount-prompt:log')
 
 /* taken from github.com/atom/settings-view/blob/master/lib/settings-panel.js
    adjsuted slightly */
-const elementForEditor = (prompt) => {
+const elementForEditor = prompt => {
   let { placeholder, title, name, description } = prompt
 
   const fragment = document.createDocumentFragment()
@@ -46,38 +46,43 @@ const elementForEditor = (prompt) => {
 }
 
 export default class PromptView extends View {
-
-  static content ({ prompts, callback }) {
+  static content({ prompts, callback }) {
     log(prompts, callback)
     this.div({ class: 'kd-prompt-view' }, () => {
       this.div({ outlet: 'prompts' })
-      this.button({
-        click: 'cancel',
-        class: 'btn cancel',
-        type: 'button'
-      }, 'CANCEL')
-      this.button({
-        click: 'submit',
-        class: 'btn btn-info pull-right submit',
-        type: 'submit'
-      }, 'MOUNT')
+      this.button(
+        {
+          click: 'cancel',
+          class: 'btn cancel',
+          type: 'button',
+        },
+        'CANCEL'
+      )
+      this.button(
+        {
+          click: 'submit',
+          class: 'btn btn-info pull-right submit',
+          type: 'submit',
+        },
+        'MOUNT'
+      )
     })
   }
 
-  initialize ({ prompts, callback }) {
+  initialize({ prompts, callback }) {
     log(callback)
     this.callback = callback
     this.editors = {}
     this.emitter = new Emitter()
     prompts.forEach(prompt => {
-      let [ fragment, editor ] = elementForEditor.call(this, prompt)
+      let [fragment, editor] = elementForEditor.call(this, prompt)
       this.editors[prompt.name] = editor
       editor.setText(prompt.defaultValue)
       this.prompts[0].appendChild(fragment)
     })
   }
 
-  submit () {
+  submit() {
     let values = {}
     for (let name in this.editors) {
       let editor = this.editors[name]
@@ -86,8 +91,7 @@ export default class PromptView extends View {
     this.callback(null, values)
   }
 
-  cancel () {
+  cancel() {
     this.callback(true)
   }
-
 }

--- a/lib/views/selector.js
+++ b/lib/views/selector.js
@@ -4,18 +4,19 @@ import { Emitter } from 'atom'
 import { SelectListView } from 'atom-space-pen-views'
 
 export default class Selector extends SelectListView {
-
-  initialize ({ items, label }) {
+  initialize({ items, label }) {
     super.initialize(items)
     this.setItems(items)
     this.addClass(`kd-selector kd-${label}-selector command-palette`)
     this.emitter = new Emitter()
   }
 
-  attached () {
+  attached() {
     this.populateList()
     /* this is to focus the input when it's ready
        if fired right away it doesn't focus */
-    setTimeout(() => { this.focusFilterEditor() }, 100)
+    setTimeout(() => {
+      this.focusFilterEditor()
+    }, 100)
   }
 }

--- a/lib/views/statusbar-icon.js
+++ b/lib/views/statusbar-icon.js
@@ -14,37 +14,44 @@ const success = {
   NOT_INSTALLED: 'kd installed…',
   NOT_LOGGEDIN: 'Logged in…',
   DAEMON_NOT_INSTALLED: 'daemon is installed',
-  DAEMON_STOPPED: 'daemon is running'
+  DAEMON_STOPPED: 'daemon is running',
 }
 
 let lastPrompt, wasSticky
 
 export default class StatusBarIcon extends View {
-
-  static content () {
-    this.div({
-      class: 'inline-block kd-statusbar-icon loading',
-      click: 'click'
-    }, () => {
-      this.raw(Icons.statusBar)
-      this.span({
-        outlet: 'message',
-        class: 'inline-block loading-message'
-      }, 'Initializing…')
-    })
+  static content() {
+    this.div(
+      {
+        class: 'inline-block kd-statusbar-icon loading',
+        click: 'click',
+      },
+      () => {
+        this.raw(Icons.statusBar)
+        this.span(
+          {
+            outlet: 'message',
+            class: 'inline-block loading-message',
+          },
+          'Initializing…'
+        )
+      }
+    )
   }
 
-  initialize ({ callback }) {
+  initialize({ callback }) {
     this.callback = callback
   }
 
-  attached (event) {
+  attached(event) {
     /* to give statusbar sometime to put other
        tiles installed by other packages */
-    setTimeout(() => { this.init() }, 1000)
+    setTimeout(() => {
+      this.init()
+    }, 1000)
   }
 
-  init () {
+  init() {
     KD.emitter.on('kd-state-all-good', () => {
       setTimeout(() => {
         this.setTooltip('command-center')
@@ -76,11 +83,11 @@ export default class StatusBarIcon extends View {
     })
   }
 
-  setLoadingMessage (message = '') {
+  setLoadingMessage(message = '') {
     this.message.html(message)
   }
 
-  setTooltip (prompt, sticky, force) {
+  setTooltip(prompt, sticky, force) {
     if (!force && prompt === lastPrompt && sticky === wasSticky) {
       return
     }
@@ -95,31 +102,33 @@ export default class StatusBarIcon extends View {
     this.disposable = atom.tooltips.add(this, {
       trigger: trigger,
       class: 'kd-statusbar-tooltip',
-      item: item
+      item: item,
     })
 
     lastPrompt = prompt
     wasSticky = sticky
   }
 
-  click () {
-    if (this.disposable) { return }
+  click() {
+    if (this.disposable) {
+      return
+    }
     this.setTooltip(lastPrompt, wasSticky, true)
   }
 
-  getItem (prompt) {
+  getItem(prompt) {
     let item
     if (prompt === 'command-center') {
       log('command-center opened')
       item = new CommandCenterView()
-      item.emitter.on('command-center:button-clicked', (target) => {
+      item.emitter.on('command-center:button-clicked', target => {
         this.callback(`show${target}`)
       })
     } else {
       log('help-view opened')
       item = new KDHelpView({
         prompt: prompt,
-        mini: true
+        mini: true,
       })
     }
     item.emitter.on('help-view-close-clicked', () => {
@@ -128,13 +137,12 @@ export default class StatusBarIcon extends View {
     return item
   }
 
-  detached () {
+  detached() {
     this.clearDisposable()
   }
 
-  clearDisposable () {
+  clearDisposable() {
     this.disposable.dispose()
     this.disposable = null
   }
-
 }

--- a/lib/views/table-view.js
+++ b/lib/views/table-view.js
@@ -7,7 +7,7 @@ import { isString, isFunction, sortBy, get, flatten } from 'lodash'
 import AtomInput from './atom-input'
 
 export default class TableView extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
 
     this.state = {
@@ -18,11 +18,11 @@ export default class TableView extends React.Component {
     }
   }
 
-  onFilterChange (filterValue) {
+  onFilterChange(filterValue) {
     this.setState({ filterValue })
   }
 
-  setSortedHeading ({ accessor, label }) {
+  setSortedHeading({ accessor, label }) {
     const { sortLabel, sortType } = this.state
 
     let newState = {}
@@ -46,7 +46,7 @@ export default class TableView extends React.Component {
     this.setState(newState)
   }
 
-  renderHeading (heading, index) {
+  renderHeading(heading, index) {
     let props = {}
 
     if (isString(heading)) {
@@ -73,13 +73,21 @@ export default class TableView extends React.Component {
     return <th key={index} {...props} />
   }
 
-  renderNoItem (noItem, colSpan) {
+  renderNoItem(noItem, colSpan) {
     return <tr><td colSpan={colSpan}>{noItem}</td></tr>
   }
 
-  render () {
-    const { title, onReload, onClose, headings,
-            items, renderRow, noItem, colCount } = this.props
+  render() {
+    const {
+      title,
+      onReload,
+      onClose,
+      headings,
+      items,
+      renderRow,
+      noItem,
+      colCount,
+    } = this.props
     const { sortAccessor, sortType, filterValue } = this.state
 
     let _items = items
@@ -129,9 +137,10 @@ export default class TableView extends React.Component {
               {headings.map(this.renderHeading.bind(this))}
             </tr>
           </thead>
-          <tbody>{_items.length
-                  ? _items.map(renderRow)
-                  : this.renderNoItem(noItem, colCount)}
+          <tbody>
+            {_items.length
+              ? _items.map(renderRow)
+              : this.renderNoItem(noItem, colCount)}
           </tbody>
         </table>
       </section>

--- a/lib/views/team-selector.js
+++ b/lib/views/team-selector.js
@@ -6,30 +6,29 @@ import Selector from './selector'
 const log = debug('kd-teams:log')
 
 export default class TeamSelector extends Selector {
-
-  getFilterKey () {
+  getFilterKey() {
     return 'name'
   }
 
-  getEmptyMessage () {
+  getEmptyMessage() {
     return 'No teams found!'
   }
 
-  viewForItem (team) {
-    return (`
+  viewForItem(team) {
+    return `
       <li>
         ${team.name}
         <cite class='pull-right'>${team.slug}.koding.com</cite>
       </li>
-    `)
+    `
   }
 
-  confirmed (team) {
+  confirmed(team) {
     this.emitter.emit('teamSelector-confirmed', team)
     return log(`${team.name} was selected`)
   }
 
-  cancelled () {
+  cancelled() {
     log('TeamSelector was cancelled')
     this.emitter.emit('teamSelector-cancelled')
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-promise": "^3.4.1",
     "eslint-plugin-react": "^6.10.3",
-    "eslint-plugin-standard": "^2.0.1"
+    "eslint-plugin-standard": "^2.0.1",
+    "prettier": "^1.2.2"
   },
   "consumedServices": {
     "status-bar": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "scripts": {
     "lint": "eslint lib",
-    "lint:fix": "eslint lib --fix"
+    "lint:fix": "eslint lib --fix",
+    "precommit": "lint-staged"
   },
   "dependencies": {
     "atom-package-deps": "^4.5.0",
@@ -46,6 +47,8 @@
     "eslint-plugin-promise": "^3.4.1",
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-standard": "^2.0.1",
+    "husky": "^0.13.3",
+    "lint-staged": "^3.4.1",
     "prettier": "^1.2.2"
   },
   "consumedServices": {
@@ -54,5 +57,11 @@
         "^1.0.0": "consumeStatusBar"
       }
     }
+  },
+  "lint-staged": {
+    "lib/**/*.js": [
+      "prettier --single-quote --trailing-comma es5 --no-semi --write",
+      "git add"
+    ]
   }
 }


### PR DESCRIPTION
This PR makes sure that `js` files under `lib` folder are formatted via `prettier` on `precommit` hook. 

it uses `lint-staged` module in collaboration with `husky` module to run the following command:

```
prettier --single-quote --trailing-comma es5 --no-semi --write "lib/**/*.js"
```

It significantly increases the time while we are committing since it checks all `js` files under it, but it's the best way to make sure that the code is formatted correctly.