### PR TITLE
Activate ssh option for only OS X

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,8 @@
 'use babel'
 
-export default {
+const platform = require('os').platform()
+
+let config = {
   localBasePath: {
     type: 'string',
     description: 'Local base path for mounting machines',
@@ -14,3 +16,14 @@ export default {
     default: '/usr/local/bin/kd',
   },
 }
+
+// right now we only support OS X.
+if (platform === 'darwin') {
+  config.terminalPath = {
+    type: 'string',
+    description: 'Default terminal app to open. e.g (Terminal, iTerm)',
+    default: 'Terminal',
+  }
+}
+
+export default config

--- a/lib/kd-controller.js
+++ b/lib/kd-controller.js
@@ -15,6 +15,7 @@ import showTreeView from './utils/show-tree-view'
 import StatusBarIcon from './views/statusbar-icon'
 import kdRun from './utils/kd-run'
 import setMountIcons from './utils/set-mount-icons'
+import openTerminal from './utils/open-terminal'
 
 const log = debug('kd-controller:log')
 const error = debug('kd:err')
@@ -224,9 +225,7 @@ export default class KDController extends kd.Object {
   }
 
   openTerminal({ machine }) {
-    // implement initial command based on machine
-    let activeEditor = atom.views.getView(atom.workspace.getActiveTextEditor())
-    atom.commands.dispatch(activeEditor, 'atom-terminal:open')
+    return openTerminal({ command: `kd ssh ${machine.alias}` })
   }
 
   runMountCmd(machine, options = {}) {

--- a/lib/utils/open-terminal.js
+++ b/lib/utils/open-terminal.js
@@ -1,0 +1,43 @@
+'use babel'
+/* globals atom */
+
+import debug from 'debug'
+import { exec } from 'child_process'
+
+const log = debug('kd:open-terminal:log')
+const error = debug('kd:open-terminal:error')
+
+export default function openTerminal({ command }) {
+  const platform = require('os').platform()
+
+  const app = atom.config.get('kd.terminalPath')
+
+  if (platform === 'darwin') {
+    const cmd = `
+      osascript <<END
+        tell application "${app}" to activate
+        tell application "System Events"
+          keystroke "n" using {command down}
+          keystroke "${command}"
+          key code 52
+        end tell
+      END
+    `
+
+    exec(cmd, (err, stdout, stderr) => {
+      if (err) {
+        error(err)
+        return atom.notifications.addError(err.message, {
+          stack: err.stack ? err.stack : null,
+        })
+      }
+      log(stdout)
+      error(stderr)
+    })
+  } else {
+    const readable = platform === 'win32' ? 'Windows' : 'Linux'
+    atom.notifications.addError(
+      `Open terminal is not supported for: ${readable}`
+    )
+  }
+}

--- a/lib/views/machine-row.js
+++ b/lib/views/machine-row.js
@@ -20,6 +20,7 @@ const MachineRow = ({
 }) => {
   const status = MachineStatusText[machine.status.state] || ''
   const isOffline = machine.status.state === MachineStatus.Offline
+  const platform = require('os').platform()
 
   const powerBtnClass = cx('btn btn-sm btn-progress icon', {
     'btn-info icon-triangle-right': !!isOffline,
@@ -64,13 +65,14 @@ const MachineRow = ({
           disabled={!!hasPowerProgress}
         />
       </td>
-      <td className="centered">
-        <button
-          className="btn btn-sm icon icon-terminal"
-          onClick={_onTerminal}
-          children="ssh"
-        />
-      </td>
+      {platform === 'darwin' &&
+        <td className="centered">
+          <button
+            className="btn btn-sm icon icon-terminal"
+            onClick={_onTerminal}
+            children="ssh"
+          />
+        </td>}
       <td className="centered">
         <button
           className={mountBtnClass}

--- a/lib/views/machines-table.js
+++ b/lib/views/machines-table.js
@@ -11,6 +11,7 @@ export default class MachinesTable extends React.Component {
   }
 
   getHeadings() {
+    const platform = require('os').platform()
     return [
       { label: 'Alias', accessor: 'alias' },
       { label: 'Team', accessor: 'team' },
@@ -20,11 +21,11 @@ export default class MachinesTable extends React.Component {
       { label: 'Provider', accessor: 'provider' },
       { label: 'Created At', accessor: 'createdAt' },
       { label: 'Copy id' },
-      { label: 'Turn on/off' },
+      platform === 'darwin' ? { label: 'Turn on/off' } : null,
       { label: 'Terminal' },
       { label: 'Mount' },
       { label: 'Always On' },
-    ]
+    ].filter(Boolean)
   }
 
   setPowerProgress(machine, state) {

--- a/lib/views/table-view.js
+++ b/lib/views/table-view.js
@@ -123,6 +123,7 @@ export default class TableView extends React.Component {
             value={filterValue}
             placeholderText="Filter..."
             onDidChange={this.onFilterChange.bind(this)}
+            onCancel={onClose}
           />
           <button className="btn btn-sm icon icon-sync" onClick={onReload}>
             Reload

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
   "deserializers": {
     "KodingController": "deserialize"
   },
-  "package-deps": [
-    "atom-terminal"
-  ],
   "scripts": {
     "lint": "eslint lib",
     "lint:fix": "eslint lib --fix",


### PR DESCRIPTION
This PR removes dependency on `atom-terminal` package, and uses `open-terminal` util to achieve the same (for only OS X)

it works for both `Terminal.app` and `iTerm`, and the app that is being used can be configured via settings panel.

Fixes #35 